### PR TITLE
 Replace 'Wordpress' with 'WordPress' to use correct camel casing acc…

### DIFF
--- a/docs/install/multi-site.md
+++ b/docs/install/multi-site.md
@@ -143,7 +143,7 @@ WordPress multi-sites do not offer multiple codebases for plugins. There is only
 !!! note
     If you're using Drupal with Domain Access, consider installing the [Domain Access CiviCRM](https://civicrm.org/extensions/domain-access-civicrm) module if users might be creating new Drupal accounts via CiviCRM profiles.
 
-Similar to Wordpress, with Domain Access module there is only one copy of the codebase, and one copy of civicrm.settings.php.
+Similar to WordPress, with Domain Access module there is only one copy of the codebase, and one copy of civicrm.settings.php.
 
 The easiest is to assign the same domain_id's in Drupal and CiviCRM, then you can just replace this line:
 

--- a/docs/integration/wordpress/incompatibilities.md
+++ b/docs/integration/wordpress/incompatibilities.md
@@ -1,6 +1,6 @@
 # WordPress plugins and themes incompatible with CiviCRM
 
-Because of the huge number and ever-changing nature of community contributed Wordpress plugins, CiviCRM cannot guarantee compatibility with contributed plugins. The following information may be of use in trying to identify conflicts, Please add to/edit this information as applicable.
+Because of the huge number and ever-changing nature of community contributed WordPress plugins, CiviCRM cannot guarantee compatibility with contributed plugins. The following information may be of use in trying to identify conflicts, Please add to/edit this information as applicable.
 
 ## Super Cache
 

--- a/docs/misc/switch-cms.md
+++ b/docs/misc/switch-cms.md
@@ -131,7 +131,7 @@ TRUNCATE TABLE `<civicrm_database>`.`civicrm_uf_match`;
 
 * On your old site, visit Administer > System Settings > Directories and Administer > System Settings > Resource URL's.
 * Copy all of your custom files and uploads to the appropriate directories on your new site.
- In Wordpress, these will likely be under wp-content/plugins/files/civicrm/civicrm
+ In WordPress, these will likely be under wp-content/plugins/files/civicrm/civicrm
  In drupal, these will likeley be under sites/default/files/civicrm.
 
 

--- a/docs/misc/switch-servers.md
+++ b/docs/misc/switch-servers.md
@@ -109,7 +109,7 @@ If you are using Joomla, Akeeba backup is a handy plugin to create complete back
         !!! check "Be Careful"
             If you have edited the IDS ini file to add any custom exclusions then you need to edit the settings for the three paths in the file, filter_path, tmp_path, HTML_Purifier_Cache. If these paths are not accessible Civi pages will display blank.
 
-    * Wordpress:
+    * WordPress:
 
         * <wordpress-root>/wp-content/plugins/files/civicrm/templates_c/*
         * <wordpress-root>/wp-content/plugins/files/civicrm/ConfigAndLog/Config.IDS.ini
@@ -125,7 +125,7 @@ If you are using Joomla, Akeeba backup is a handy plugin to create complete back
     * Drupal sites: http://<drupal_site>/index.php?q=civicrm/admin/setting/updateConfigBackend&reset=1
     * Joomla 1.5 sites: http://<joomla_site>/administrator/index2.php?option=com_civicrm&task=civicrm/admin/setting/updateConfigBackend&reset=1
     * Joomla 1.6 sites: http://<joomla_site>/administrator/index.php?option=com_civicrm&task=civicrm/admin/setting/updateConfigBackend&reset=1
-    * Wordpress sites: http://<wordpress_site>/wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/setting/updateConfigBackend&reset=1
+    * WordPress sites: http://<wordpress_site>/wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/setting/updateConfigBackend&reset=1
         * Prior to 4.3.3 the WordPress implementation mistakenly drops everything after the domain in its suggestion for a new URL. The default location for a WordPress install relative to docroot would normally mean that the url should be http://<wordpress_site>/wp-content/plugins/civicrm/civicrm/
         
 1. Review the recommended modified paths in the form - they should reflect the new Base Directory, Base URL, and Site name for CiviCRM.

--- a/docs/planning/cms.md
+++ b/docs/planning/cms.md
@@ -4,7 +4,7 @@ CiviCRM works with the three most popular open source Content Management Systems
 
 -   Drupal
 -   Joomla
--   Wordpress
+-   WordPress
 
 Before starting a project you should consider how you plan to use
 CiviCRM both now and in the future. Two big questions are; How much
@@ -31,7 +31,7 @@ Drupal. Joomla is easier to learn than Drupal. The amount of integration
 available is lower than then when using Drupal.
 
 **WordPress** is by a wide margin the most popular of the three CMS's.
-It is considered to be very easy to build sites using Wordpress,
+It is considered to be very easy to build sites using WordPress,
 especially for people that are not familiar with web technology. A lot
 of people know WordPress as a blogging platform rather than a CMS, but
 it is becoming more powerful and flexible with each release. The amount

--- a/docs/setup/civimail/index.md
+++ b/docs/setup/civimail/index.md
@@ -560,7 +560,7 @@ Drupal:
 wget -O - -q -t 1 \
 'http://[SITEROOT]/sites/all/modules/civicrm/bin/cron.php?name=username&pass=password&key=site-key'
 
-Wordpress:
+WordPress:
 wget -O - -q -t 1 \
 'http://[SITEROOT]/wp-content/plugins/civicrm/civicrm/bin/cron.php?name=username&pass=password&key=site-key'
 ```
@@ -591,7 +591,7 @@ Joomla: http://[SITEROOT]/administrator/components/com_civicrm/civicrm/bin/cron.
 
 Drupal: http://[SITEROOT]/sites/all/modules/civicrm/bin/cron.php?name=username&pass=password&key=site-key
 
-Wordpress: http://[SITEROOT]/wp-content/plugins/civicrm/civicrm/bin/cron.php?name=username&pass=password&key=site-key
+WordPress: http://[SITEROOT]/wp-content/plugins/civicrm/civicrm/bin/cron.php?name=username&pass=password&key=site-key
 ```
 
 If the above works, it means CiviCRM is working OK, but the cron on your server is not configured properly. Try _crontab -e_ and review it again.

--- a/docs/upgrade/wordpress.md
+++ b/docs/upgrade/wordpress.md
@@ -37,7 +37,7 @@ The ["Before upgrading"](/upgrade/index.md#before-upgrading) steps describe step
 
     The installer in 4.7 does not assume that the content-dir is wp-content. It probably is, but can be renamed/moved as detailed [here](https://codex.wordpress.org/Editing_wp-config.php#Moving_wp-content_folder)
     
-Copy this file to a location outside your Wordpress project. You will need to restore it after upgrading.
+Copy this file to a location outside your WordPress project. You will need to restore it after upgrading.
 
 * Also, if you are using the `<wordpress_root>/wp-content/plugins/civicrm/civicrm/settings_location.php` file in your implementation, make a copy of this as well.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ pages:
   #- Backdrop integration:
     #- Backdrop integration: integration/backdrop/index.md
   - WordPress integration:
-    - Wordpress integration: integration/wordpress/index.md
+    - WordPress integration: integration/wordpress/index.md
     - Forms in WordPress: integration/wordpress/forms.md
     - Incompatible plugins: integration/wordpress/incompatibilities.md
   - Joomla integration:


### PR DESCRIPTION
…ording to the WordPress Wordmark and Trademark