### PR TITLE
CRM-21425: Make Inbound Emails Editable With Configuration Option

### DIFF
--- a/docs/setup/civimail/index.md
+++ b/docs/setup/civimail/index.md
@@ -232,8 +232,16 @@ time):
 Activities created by CiviCRM as a result of email-to-activity processing 
 are not editable by users, as there is a restriction enforced on the Inbound 
 Email activity type. To allow users to be able to edit these activities, an
-administrator can enable the **Allow to Edit Inbound E-mails** option found on 
-**Administer > CiviMail > CiviMail Component Settings**
+administrator can enable the **CiviCRM: edit inbound email basic information** 
+or **CiviCRM: edit inbound email basic information and content** permissions
+for the roles that should be able to edit the activities.
+
+**CiviCRM: edit inbound email basic information** will allow users to edit every
+field of the activity, except the original message, stored int the activity's 
+details.
+
+**CiviCRM: edit inbound email basic information and content** will allow users
+to edit every field of the activity, including the original message's content.
 
 ### Special email address for incoming email
 

--- a/docs/setup/civimail/index.md
+++ b/docs/setup/civimail/index.md
@@ -208,7 +208,7 @@ it as an email activity against contacts of type Individual corresponding to
 sender and recipients of the email. New individual contacts are created for
 email addresses not already assigned to individuals in the database.
 
-**NOTE**: This features only works for the Individual contact type. If the
+**NOTE**: These features only work for the Individual contact type. If the
 incoming email comes from an email address already recorded against an
 organization, a new individual contact with that same email address will be
 created and the activity will be recorded against that new individual contact,
@@ -226,6 +226,14 @@ time):
     drag emails that you want filed in CiviCRM. This works with both
     inbound and outbound emails (this requires that your email be set
     up using IMAP.)
+
+### Allowing users to edit inbound e-mails
+
+Activities created by CiviCRM as a result of email-to-activity processing 
+are not editable by users, as there is a restriction enforced on the Inbound 
+Email activity type. To allow users to be able to edit these activities, an
+administrator can enable the **Allow to Edit Inbound E-mails** option found on 
+**Administer > CiviMail > CiviMail Component Settings**
 
 ### Special email address for incoming email
 


### PR DESCRIPTION
Overview
----------------------------------------
On some business cases, it may be required to be able to edit an activity type of 'Inbound E-mail', for example, to add an observation or edit some custom fields to implement some kind of workflow. However, this is currently not possible, as the prohibition for this type of activities is hard-coded in several parts within CiviCRM.

This new option to allow users to edit activities of Inbound Email type is being added on this PR:
https://github.com/civicrm/civicrm-core/pull/12445