### PR TITLE
Remove generic mentions to forum

### DIFF
--- a/docs/install/backdrop.md
+++ b/docs/install/backdrop.md
@@ -124,8 +124,4 @@ There should now be a **CiviCRM** link in your Backdrop menu. Click that link an
 
 ## Trouble-shooting Resources {:#troubleshooting}
 
-Review the [Installation and Configuration Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
-
-You can often find solutions to your issue by searching the [installation support section of the community forum](http://forum.civicrm.org/index.php/board,6.0.html) OR the [community mailing list archives](http://www.nabble.com/CiviCRM-Community-Mailing-List-Archives-f15986.html), and you can check out the Installation section of our FAQs.
-
-If you don't find an answer to your problem in those places, the next step is to [post a support request on the forum](http://forum.civicrm.org/index.php/board,6.0.html).
+* Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.

--- a/docs/install/drupal7.md
+++ b/docs/install/drupal7.md
@@ -132,10 +132,5 @@ There should now be a **CiviCRM** link in your Drupal menu. Click that link and 
 
 ## Trouble-shooting Resources {:#troubleshooting}
 
-Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
-
-You can often find solutions to your issue by searching the [installation support section of the community forum](http://forum.civicrm.org/index.php/board,6.0.html) OR the [community mailing list archives](http://www.nabble.com/CiviCRM-Community-Mailing-List-Archives-f15986.html), and you can check out the Installation section of our FAQs.
-
-If you don't find an answer to your problem in those places, the next step is to [post a support request on the forum](http://forum.civicrm.org/index.php/board,6.0.html).
-
-To check compatibility with other Drupal modules see: [Drupal modules incompatible with CiviCRM](/integration/drupal/incompatibilities.md)
+* Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
+* To check compatibility with other Drupal modules see: [Drupal modules incompatible with CiviCRM](/integration/drupal/incompatibilities.md)

--- a/docs/install/joomla.md
+++ b/docs/install/joomla.md
@@ -46,30 +46,27 @@ When CiviCRM is installed on top of an existing Joomla site, a special CiviCRM A
 
 ## Troubleshooting Resources {:#troubleshooting}
 
-If the CiviCRM component does not install correctly (for example you get a blank screen instead of the confirmation page), delete the `~/components/com_civicrm` and `~/administrator/components/com_civicrm` and `~/media/civicrm directories` manually and then try each of the following before attempting to reinstall:
+* If the CiviCRM component does not install correctly (for example you get a blank screen instead of the confirmation page), delete the `~/components/com_civicrm` and `~/administrator/components/com_civicrm` and `~/media/civicrm directories` manually and then try each of the following before attempting to reinstall:
 
-* In your `php.ini` file or in `.htaccess` file in the Joomla root folder (if your server allows it), increase the `max_execution_time` to `600` and memory limit to more than 64M. Add the following to the `.htaccess` file in your Joomla root folder
-
-    ```
-    php_value memory_limit 128M
-    php_value register_globals off
-    php_value max_execution_time 600
-    ```
+    * In your `php.ini` file or in `.htaccess` file in the Joomla root folder (if your server allows it), increase the `max_execution_time` to `600` and memory limit to more than 64M. Add the following to the `.htaccess` file in your Joomla root folder
     
-    Or if you can't change the `.htaccess` file you can add a php.ini (or `.user.ini`) file in Joomla root folder or all directories, depending on your web server or hosting company.
+        ```
+        php_value memory_limit 128M
+        php_value register_globals off
+        php_value max_execution_time 600
+        ```
+        
+        Or if you can't change the `.htaccess` file you can add a php.ini (or `.user.ini`) file in Joomla root folder or all directories, depending on your web server or hosting company.
+        
+        ```
+        memory_limit = 128M
+        register_globals = off
+        max_execution_time = 600
+        ```
     
-    ```
-    memory_limit = 128M
-    register_globals = off
-    max_execution_time = 600
-    ```
+    * CiviCRM is packaged with all the libraries (PEAR etc) that it uses. However a misconfigured or overly restrictive `open_basedir` directive on your web server might interfere with CiviCRM's ability to access some required files or directories. To turn `open_basedir` off, add this to your `vhost.conf` file: `php_admin_value open_basedir none` or ask your host to either turn it off or ensure that it is not preventing access to required directories (e.g. if you move configuration files or temp folders outside your web root). The configuration of sub domains might cause related issues: try installing in the main domain root or a sub folder instead.
 
-* CiviCRM is packaged with all the libraries (PEAR etc) that it uses. However a misconfigured or overly restrictive `open_basedir` directive on your web server might interfere with CiviCRM's ability to access some required files or directories. To turn `open_basedir` off, add this to your `vhost.conf` file: `php_admin_value open_basedir none` or ask your host to either turn it off or ensure that it is not preventing access to required directories (e.g. if you move configuration files or temp folders outside your web root). The configuration of sub domains might cause related issues: try installing in the main domain root or a sub folder instead.
+* If CiviCRM screens are not displaying properly and/or javascript widgets are not functioning, check your CiviCRM Resource URL (Administer >> System Settings >> Resource URLs). For Joomla installs, it should be something like: `http://example.org/administrator/components/com_civicrm/civicrm`
 
-If CiviCRM screens are not displaying properly and/or javascript widgets are not functioning, check your CiviCRM Resource URL (Administer >> System Settings >> Resource URLs). For Joomla installs, it should be something like: `http://example.org/administrator/components/com_civicrm/civicrm`
+* Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
 
-Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
-
-You can often find solutions to your issue by searching the [installation support section of the community forum](http://forum.civicrm.org/index.php/board,2.0.html) OR the [community mailing list archives](http://www.nabble.com/CiviCRM-Community-Mailing-List-Archives-f15986.html), and you can check out the Installation section of our FAQs.
-
-If you don't find an answer to your problem in those places, the next step is to [post a support request on the forum](http://forum.civicrm.org/index.php/board,2.0.html).

--- a/docs/install/wordpress.md
+++ b/docs/install/wordpress.md
@@ -162,10 +162,6 @@ When a new, stable version of CiviCRM is released it is recommended you upgrade 
   1. Delete all files in `<wordpress>/wp-content/plugins/files/civicrm/templates_c/` and clear browser cache
   1. Run the Upgrade script at: `http://example.org/wp-admin/admin.php?page=CiviCRM&q=civicrm/upgrade&reset=1`
 
-## Trouble-shooting Resources
+## Trouble-shooting Resources {:#troubleshooting}
 
-Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.
-
-You can often find solutions to your issue by searching the **[installation support section of the community forum](http://forum.civicrm.org/index.php/board,64.0.html)** and you can check out the **Installation section of our FAQs**.
-
-If you don't find an answer to your problem in those places, the next step is to **[post a support request on the forum](http://forum.civicrm.org/index.php/board,64.0.html)**.
+* Review the [Troubleshooting](/troubleshooting.md) page for help with problems you may encounter during the installation.

--- a/docs/integration/drupal/index.md
+++ b/docs/integration/drupal/index.md
@@ -107,8 +107,8 @@ Settings > CMS Database Integration** shows some code that must be
 copied and pasted into the Drupal *settings.php* file after (but not
 replacing) the existing database connection code. If you have trouble
 consider asking for help in
-the [forums](http://forum.civicrm.org/) or [hiring a
-consultant](http://civicrm.org/what/experts). If you are using Custom
+[Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org); or consider [hiring a
+consultant](https://civicrm.org/partners-contributors). If you are using Custom
 Data sets in CiviCRM, anytime you add a new data **set** (not just a
 field) you must repeat this process.
 
@@ -129,8 +129,9 @@ fields for those types.
 After the View is created, edit the fields, filters, display and other
 configurations to show the data exactly how you'd prefer. Views does
 take some experimentation and/or training to get it right. Feel free to
-ask questions on the [forums](http://forum.civicrm.org/) or [hire a
-consultant](http://civicrm.org/what/experts) if you become stuck.
+ask questions on [Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org)
+&mdash; or [hire a
+consultant](https://civicrm.org/partners-contributors) if you become stuck.
 
 ![Screenshot demonstrating the "Edit view" page](/img/Views-CiviCRM-Partner-3.png)  
 

--- a/docs/planning/demo.md
+++ b/docs/planning/demo.md
@@ -21,7 +21,7 @@ can't set permissions for Drupal users or do a full exploration of
 online payment options.
 
 If you are having trouble working on a demo site, contact the CiviCRM
-core team via the forum or IRC. If you want a more controlled
+[Core Team](https://civicrm.org/teams/core-team). If you want a more controlled
 environment for exploring CiviCRM, install your own test site.
 
 ## Test installations

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -98,7 +98,7 @@ CiviCRM performs various operations based on dates and times – for example, de
 
 * PHP and MySQL may be running on different servers, and the clocks may be out-of-sync. Configuring automatic clock synchronization is the best solution.
 * PHP, MySQL, and/or the operating system may be configured to use different default timezones. Verify the configuration of each.
-* The content management system (Drupal, Joomla, or WordPress) or one of its plugins may manipulate the timezone settings without CiviCRM's awareness. You may wish to post to the [CiviCRM Forum](http://forum.civicrm.org/) about your problem. Please include any available details about the timezone settings in the operating system, PHP, MySQL, and the CMS; if you have any special CMS plugins or configuration options which may affect timezones, please report them.
+* The content management system (Drupal, Joomla, or WordPress) or one of its plugins may manipulate the timezone settings without CiviCRM's awareness. You may wish to post to [Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org) about your problem. Please include any available details about the timezone settings in the operating system, PHP, MySQL, and the CMS; if you have any special CMS plugins or configuration options which may affect timezones, please report them.
 
 
 ### MySQL permissions

--- a/docs/upgrade/joomla.md
+++ b/docs/upgrade/joomla.md
@@ -60,7 +60,7 @@ http://example.org/administrator/index.php?option=com_civicrm&task=civicrm/upgra
 
 You should see an **Upgrade successful** message when the upgrade completes.
 
-1. If you receive any errors during the process, please note the exact error message and check for solutions on the community support forum.
+1. If you receive any errors during the process, please note the exact error message and check for solutions on [Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org).
 1. Now click the **Return to CiviCRM home page** link.
 1. You should be up and running with the latest CiviCRM version. Confirm by checking the version and revision in the page footer. Note that you may need to refresh the browser screen a couple times to clear out your local cache and ensure the layout loads correctly.
 1. Take some time to browse the CiviCRM features that your organization uses. If you notice unexpected behaviors or error messages, refer to the trouble-shooting section below.

--- a/docs/upgrade/wordpress.md
+++ b/docs/upgrade/wordpress.md
@@ -114,7 +114,7 @@ Delete all files in your `templates_c` directory
 1. You should see the Upgrade screen.
 1. If you are ready to upgrade, click the **Upgrade Now** button.
 1. You should see the message **Upgrade successful** when the upgrade completes.
-    * If you receive any errors during the process, please note down the exact error message, and check for solutions on the [community support forum](http://forum.civicrm.org/).
+    * If you receive any errors during the process, please note down the exact error message, and check for solutions on [Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org).
     
 1. Now click the **Return to CiviCRM home page** link. This will rebuild CiviCRM menus automatically and return you to the CiviCRM home dashboard.
 


### PR DESCRIPTION
This PR intends to resolve #70 by removing mentions to the forum. 

* Instead of directing users to the forum for generic help, direct them to Mattermost and Stack Exchange.
* Retains links to *specific* forum posts.