### PR TITLE
Add node to requirements document about MySQL SQL Modes

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -88,12 +88,18 @@ Your MySQL version must be **5.1.3 or greater**.
  
 ### MySQL configuration
 
-* Support for the `innodb` storage engine is required
-* The `thread_stack` configuration variable should be set to 192k or higher
-* Trigger support is required
-
-    !!! note "MySQL Modes"
-        There have been some issues generated through different SQL modes being set. In MySQL 5.7+ the SQL mode ONLY_FULL_GROUP_BY is enabled by default. This has generated some issues due to sql construction. Administrators are able to turn off specific SQL modes by setting the sql_mode varaiables as per the [MySQL Documentation](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting)
+* Support for the `innodb` storage engine is required.
+* The `thread_stack` configuration variable should be set to 192k or higher.
+* Trigger support is required.
+* The `ONLY_FULL_GROUP_BY` mode should be turned off.
+    * In MySQL 5.7+ the SQL mode `ONLY_FULL_GROUP_BY` is enabled by default which causes some errors due to some of CiviCRM's SQL queries that were written with the assumption that this mode would be disabled.
+    * Administrators are advised to turn off this SQL mode by removing the string `ONLY_FULL_GROUP_BY` from the `sql_mode` variable. The following SQL query will do the trick.
+        ```sql
+        SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+        ```
+    * See also:
+        * A popular [Stack Exchange question](https://stackoverflow.com/a/36033983/895563) discussing this issue
+        * [MySQL documentation on `sql_mode`](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting)
 
 #### MySQL time
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -92,6 +92,9 @@ Your MySQL version must be **5.1.3 or greater**.
 * The `thread_stack` configuration variable should be set to 192k or higher
 * Trigger support is required
 
+    !!! note "MySQL Modes"
+        There have been some issues generated through different SQL modes being set. In MySQL 5.7+ the SQL mode ONLY_FULL_GROUP_BY is enabled by default. This has generated some issues due to sql construction. Administrators are able to turn off specific SQL modes by setting the sql_mode varaiables as per the [MySQL Documentation](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting)
+
 #### MySQL time
 
 CiviCRM performs various operations based on dates and times – for example, deactivating expired records or triggering scheduled reminders. To perform these operations correctly, the dates and times reported by PHP and MySQL should match. If the dates or times are mismatched, then one or more of the following may be the problem:


### PR DESCRIPTION
@seanmadsen this adds a note about SQL modes as we have seen some issues with full group by as evidenced by https://civicrm.stackexchange.com/search?q=only_full_group_by. I think this will at least point people potentially towards how to solve issues perhaps