### PR TITLE
Prepare for CiviCRM 5.0 release

### DIFF
--- a/docs/install/wordpress.md
+++ b/docs/install/wordpress.md
@@ -93,7 +93,7 @@ The installer will verify that you've downloaded the correct version of CiviCRM,
 * Go to plugins page: `http://example.org/wp-admin/plugins.php`.
 * Click the **Activate** link to activate the CiviCRM plugin.
 * Then go to Settings > CiviCRM Installer: `http://example.org/wp-admin/options-general.php?page=civicrm-install`
-    * In version 4.7 you will see a link on the wp-admin page to the Installer screen
+    * In version 4.7 and above you will see a link on the wp-admin page to the Installer screen
 
 * You should see the **CiviCRM Installer** screen.
 

--- a/docs/integration/wordpress/index.md
+++ b/docs/integration/wordpress/index.md
@@ -96,7 +96,7 @@ Features
 To use this plugin, the following is needed:
 
 * WordPress
-* CiviCRM 4.6.x or 4.7.x
+* CiviCRM 4.6 and above
 * [Caldera Forms](https://wordpress.org/plugins/caldera-forms/) to be installed
 
 [Download](https://github.com/mecachisenros/caldera-forms-civicrm)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -47,7 +47,7 @@ See our page on [choosing a CMS](/planning/cms.md) for more information about th
 
 ### PHP version
 
-|  | CiviCRM 4.6.x | CiviCRM 4.7.x |
+|  | CiviCRM 4.6.x | CiviCRM 4.7+ |
 | -- | -- | -- |
 | PHP 7.2 | **incompatible** | _not yet tested_ |
 | PHP 7.1 | **incompatible** | compatible with CiviCRM 4.7.24 and later, but **not recommended** due to insufficient testing |

--- a/docs/upgrade/wordpress.md
+++ b/docs/upgrade/wordpress.md
@@ -35,7 +35,7 @@ The ["Before upgrading"](/upgrade/index.md#before-upgrading) steps describe step
 
     `<wordpress_root>/content-dir/uploads/civicrm/civicrm.settings.php`
 
-    The installer in 4.7 does not assume that the content-dir is wp-content. It probably is, but can be renamed/moved as detailed [here](https://codex.wordpress.org/Editing_wp-config.php#Moving_wp-content_folder)
+    The installer in 4.7 and above does not assume that the content-dir is wp-content. It probably is, but can be renamed/moved as detailed [here](https://codex.wordpress.org/Editing_wp-config.php#Moving_wp-content_folder)
     
 Copy this file to a location outside your WordPress project. You will need to restore it after upgrading.
 


### PR DESCRIPTION
This PR generalizes the language here so that all references to CiviCRM 4.7 apply equally to CiviCRM 5.0. I think it should be okay to merge now since it dosen't mention 5.0 explicitly. As well, I think that once 5.0 is released, we shouldn't need to make any more changes to the Sysadmin Guide.