### PR TITLE
Recommend PHP 7.1 for civi 5.x.x

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -47,7 +47,7 @@ See our page on [choosing a CMS](/planning/cms.md) for more information about th
 
 ### PHP version
 
-|  | CiviCRM 4.6.x | CiviCRM 4.7+ | CiviCRM 5.x |
+|  | CiviCRM 4.6.x | CiviCRM 4.7.x | CiviCRM 5.x.x |
 | -- | -- | -- | -- |
 | PHP 7.2 | **incompatible** | _not yet tested_ |  _not yet tested_ |
 | PHP 7.1 | **incompatible** | compatible with CiviCRM 4.7.24 and later, but **not recommended** due to insufficient testing | compatible |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -50,7 +50,7 @@ See our page on [choosing a CMS](/planning/cms.md) for more information about th
 |  | CiviCRM 4.6.x | CiviCRM 4.7.x | CiviCRM 5.x.x |
 | -- | -- | -- | -- |
 | PHP 7.2 | **incompatible** | _not yet tested_ |  _not yet tested_ |
-| PHP 7.1 | **incompatible** | compatible with CiviCRM 4.7.24 and later, but **not recommended** due to insufficient testing | compatible |
+| PHP 7.1 | **incompatible** | compatible with CiviCRM 4.7.24 and later, but **not recommended** due to insufficient testing | compatible and **recommended** |
 | PHP 7.0 | **incompatible** | compatible and **recommended** | compatible and **recommended** |
 | PHP 5.6 | compatible and **recommended** | compatible and **recommended** | compatible and **recommended** |
 | PHP 5.5 | compatible, but **not recommended** due to to [PHP end-of life](http://php.net/eol.php) in July 2016 | compatible, but **not recommended** due to to [PHP end-of life](http://php.net/eol.php) in July 2016 | **incompatible** |


### PR DESCRIPTION
I have been running CiviCRM locally with PHP 7.1 for development purposes for many months now. I've been keeping an eye out for errors and notices, and all has seemed well. 

By the end of this year, 7.1 will be the lowest version of PHP that's not EOL'd, so I think we better start officially recommending that people use it. This [question came up on Mattermost](https://chat.civicrm.org/civicrm/pl/u1u7i8n5zjffpruz5da5e7matr).

Then, I think in 2019-01 we should remove "Recommended" from PHP versions below 7.1. I'm really not sure where this leaves the LTS version, but that's a question for another day! 