### PR TITLE
In cron cv instructions, add command to change working directory to site root

### DIFF
--- a/docs/setup/jobs.md
+++ b/docs/setup/jobs.md
@@ -69,7 +69,7 @@ Some of these methods require a valid username and password (for a CMS user who 
 [`cv`](https://github.com/civicrm/cv) is a CLI utility for CiviCRM, like [`drush`](http://www.drush.org/en/master/) is to Drupal, [`wp-cli`](http://wp-cli.org/) to WordPress, and [Joomlatools Console](https://www.joomlatools.com/developer/tools/console/) to Joomla. Once you have `cv` installed, you can execute CiviCRM's scheduled jobs with this command:
 
 ```
-cv api --user=admin job.execute
+cd /var/www/example.org; cv api --user=admin job.execute
 ```
 
 ### Drush method {:#drush}


### PR DESCRIPTION
Without the `cd` command, the `cv` command most likely won't run properly.