### PR TITLE
Cron jobs - Document use of --cwd argument now available in cv

### DIFF
--- a/docs/setup/jobs.md
+++ b/docs/setup/jobs.md
@@ -69,7 +69,7 @@ Some of these methods require a valid username and password (for a CMS user who 
 [`cv`](https://github.com/civicrm/cv) is a CLI utility for CiviCRM, like [`drush`](http://www.drush.org/en/master/) is to Drupal, [`wp-cli`](http://wp-cli.org/) to WordPress, and [Joomlatools Console](https://www.joomlatools.com/developer/tools/console/) to Joomla. Once you have `cv` installed, you can execute CiviCRM's scheduled jobs with this command:
 
 ```
-cv api --user=admin job.execute
+cv api job.execute --user=admin --cwd=/var/www/example.org
 ```
 
 ### Drush method {:#drush}


### PR DESCRIPTION
Closes https://github.com/civicrm/cv/issues/41.  Also rearranges the arguments - both methods work, but this is the documented correct order.