### PR TITLE
Mostly remove the instructions on phpmyadmin

### DIFF
--- a/docs/misc/switch-servers.md
+++ b/docs/misc/switch-servers.md
@@ -94,6 +94,18 @@ See below if you have a Drupal 8 composer installation, or other composer instal
         $ mysql -u mysql_username -p joomla_db_name < dump_file_name_of_your_choice.sql
         ```
     
+!!! note
+    The above two steps, exporting the database from the source and importing to the target, 
+    can also be performed in phpMyAdmin, although for exporting or importing a large database phpMyAdmin tends to time out
+    and using command line is more reliable. The steps to export and import the database in phpMyAdmin are as follows:
+    1. In the PHPMyAdmin interface, select your existing civiCRM database and then select the export feature.
+    1. Under Export Method, select 'Quick' with format 'SQL.'
+    1. Click the submit button to export your database which should then download somewhere onto your computer.
+    1. Import the data by navigating to the new website's PHPMyAdmin system and doing a simple, 
+    no frills import, using the data you just downloaded. The import should be into a new database created for CiviCRM 
+    (or an existing database which has been emptied by deleting all tables), with suitable permissions for the database user 
+    configured in the new sites civicrm.settings.php.
+
 1. Delete files with cached settings
 
     * Drupal:
@@ -277,75 +289,3 @@ This seems to be caused by the database backup and restore not copying the funct
 The solution is to run `http://example.org/civicrm/menu/rebuild?reset=1&triggerRebuild=1` which fixes the trigger and function definitions in the database.
 
 On Joomla sites run `http://example.org/administrator/?option=com_civicrm&task=civicrm/menu/rebuild&reset=1&triggerRebuild=1`
-
-
-
-## Moving the database using phpMyAdmin
-
-This is an alternate method for moving a civiCRM installation from one server to another. This method has worked well for moving Drupal/CiviCRM based websites from development servers to production servers and uses the Backup and Migrate module for transferring the Drupal data and PHPMyAdmin for the civiCRM data.
-
-### Preliminary Setup
-
-These are the steps I take to prepare a new installation of Drupal and civiCRM for taking on the content and CRM data of an existing production site or moving a site from a development environment to a live production server:
-
-1. Before moving the site make sure that the Drupal/CiviCRM development site is up to date with core and contributed modules.
-
-1. On the new server install a fresh installation of Drupal using the same version as that of the site you are transferring. I start fresh with files from Drupal.org rather than transferring my files from the development server to ensure that they have not been compromised somewhere during the development process.
-
-1. Once an empty Drupal site is installed and working correctly, I move my `/sites/all` directories into the Drupal installation. This gives me my themes, modules and libraries.
-**Note:** I _don't move_ `/sites/all/modules/civicrm because` I am more comfortable using a new copy from the civiCRM website, just in case something has been compromised during development or transferring.
-
-1. I also move select directories from my `/sites/default/files` directory.
-**Note:** I _don't move_ any of the cached directories under `/sites/default/files` and I don't move `/sites/default/files/civicrm`
-
-1. Next, I install a brand new copy of civiCRM into the website by running the standard installation script from within `/sites/all/modules/civicrm/install/`
-**Note:** Go thorough the configuration checklist just to make sure everything appears to be correct but don't spend a lot of time on it because it will be overwritten when you transfer the data.
-
-1. At this point, the new site should be an empty canvas with all of the components of the site that you are moving but without any of the data, design or structure yet. Make sure that you have the site theme on hand and that all of the modules that are present in the site that you are moving. Also, have a look at the site and server reports to ensure that everything is functioning as it should without any errors or resource problems.
-
-
-### Export/Transfer Drupal CMS Data
-
-For transferring Drupal site data I like to use the excellent Backup and Migrate module ([http://drupal.org/project/backup_migrate](http://drupal.org/project/backup_migrate)) but you can use PHPMyAdmin if that makes you more comfortable. Transferring the Drupal data for a Drupal/civiCRM website is no different than any other Drupal site but do not use the Backup and Migrate module for moving the civiCRM data. In my experience it will not work.
-
-At this point I transfer my Drupal data and the site should have all of the CMS data, navigation and theming intact. Only CRM data is missing now.
-
-### Export/Transfer civiCRM Data
-
-Exporting the civiCRM data can be a bit tricky because civiCRM seems intimately aware of its server/database environment. There are a number of areas established during installation where civiCRM keeps track of its surroundings and if we aren't careful we will overwrite them and then we'll have to start from scratch. It's not that bad but it gets a little tedious once you've gotten to the 80% done part and have to start over.
-
-The following points cover how I export data using PHPMyAdmin and avoid tripping myself up:
-
-1. In the PHPMyAdmin interface, select your existing civiCRM database and then select the export feature.
-
-1. Under Export Method, select: _**"Custom - display all possible options"**_
-
-1. In the tables area deselect (hold down control or option depending on OS and deselect the following 5 tables):
-
-    1. civicrm_acl_cache
-    1. civicrm_acl_contact_cache
-    1. civicrm_cache
-    1. civicrm_domain
-    1. civicrm_group_contact_cache
-
-1. Make sure that you check the "Disable foreign key checks" option.
-1. Under Object Creation Options check the "Add DROP TABLE / VIEW / PROCEDURE / FUNCTION / EVENT statement" option
-1. Click the submit button to export your table which should then download somewhere onto your computer.
-1. Import the data by navigating to the new website's PHPMyAdmin system and doing a simple, no frills import using the data you just downloaded. It should just import the data and overwrite the existing tables with your civiCRM data.
-
-### Post Import Activities
-
-After you have imported the civiCRM data, there are some tasks that need to be done in order to flush out caches and provide a clean slate for civiCRM and Drupal to work together.
-
-1. I always run the following SQL queries that I gleaned from the civiCRM support Forums
-    * On your civiCRM Database Run
-        1. truncate civicrm_uf_match;
-        1. update civicrm_domain set config_backend = null;
-
-    * On your Drupal Database run:
-        1. truncate sessions;
-
-1. In /sites/default/files/civicrm, delete or rename the folder `templates_c`. A new one will be created when civiCRM is run.
-1. Navigate to the civiCRM Configuration Checklist ([www.example.com/civicrm/admin/configtask?reset=1)](http://www.example.com/civicrm/admin/configtask?reset=1%29) and review the setting to make sure that they are correct. More than likely the settings for language, default country and other regional settings will be incorrect. Take extra care to ensure that your directories are set up correctly, especially if you use custom templates for one reason or another.
-1. **Very Important:** If you have custom data profiles set up in your civiCRM, they may be present but for some unknown reason not be active. Go to your Administer >> Customize >> Custom Data and select _**"View and Edit Custom Fields"**_. Select **_"Edit Field"_** for any one of the custom fields in the group and save it without making any changes. This will make civiCRM aware of the custom data fields and everything should be back on track.
-1. If you have Drupal user Profiles that relate to the civiCRM contacts, you will want to run **_"Synchronize Users to Contacts"_**. It can be found at Administer >> Manage >> Synchronize Users to Contacts


### PR DESCRIPTION
As I noted in issue #85, the section on the phpMyAdmin migration mainly repeats the procedures already set out, substituting the use of phpmyadmin for a database export and import into a pre-install CiviCRM db. The steps for the db export in this phpmyadmin section may or may not create errors, and importing a full db dump, including cache tables, into an empty db, is simpler and cleaner. 

The whole phpmyadmin section has been removed, and a brief note on using phpMyAdmin for export/import added in the main sequence of text. This section is still available publicly at https://wiki.civicrm.org/confluence/display/CRMDOC42/Alternate+Moving+the+database+using+phpMyAdmin