### PR TITLE
Sort out documentation for IPN notify URL so it is in a shared location.

### DIFF
--- a/docs/setup/payment-processors/authorize-net.md
+++ b/docs/setup/payment-processors/authorize-net.md
@@ -96,15 +96,11 @@ If you would like to use an Authorize.net Developer Test Account, you can sign u
 
 Authorize.net offers a recurring payment system called Automated Recurring Billing (ARB) for an additional fee. Your **Settings - Payment Processor** page will automatically populate with the standard Recurring Payments URL, but you will need to enable the ARB service in order for recurring contributions to work.
 
-CiviCRM will need to be notified of the success of recurring contributions via a **Silent Post URL**. Within CiviCRM, get the ID number of your payment processor by looking at the URL of the form for editing your payment processor: it should read "&id=" followed by a number. That number is your ID. Within Authorize.net, go to **Account > Settings > Silent Post URL** (within the Transaction Format Settings section). On that page, enter the URL (the following examples are for payment processor ID 2):
+CiviCRM will need to be notified of the success of recurring contributions via a **Silent Post URL**.
 
-```
-Drupal: http://example.org/civicrm/payment/ipn/2
+Follow the instructions here: [IPN Notify URL](/setup/payment-processors/recurring.md#IPN%20notify%20URL) to work out the correct URL to use.
 
-Joomla!: http://example.org/index.php?option=com_civicrm&task=civicrm/payment/ipn/2
-
-WordPress: http://example.org/?page=CiviCRM&q=civicrm/payment/ipn/2
-```
+Within Authorize.net, go to **Account > Settings > Silent Post URL** (within the Transaction Format Settings section). On that page, enter the appropriate IPN / Webhook URL.
 
 If you fail to do this, one-time contributions will succeed normally, and recurring contributions will be processed successfully by Authorize.net, but the contribution status will be stuck at Pending.
 

--- a/docs/setup/payment-processors/paypal-pro.md
+++ b/docs/setup/payment-processors/paypal-pro.md
@@ -231,17 +231,18 @@ The differences between Paypal Standard Subscriptions and Paypal Pro Recurring C
 
 To take advantage of recurring and one-time contributions on the same CiviCRM Contribution page, you must have the Pro Recurring add on. You cannot process Pro one-time donations and Standard Subscriptions from the same Contribution page.
 
-Once you have added the Recurring feature to your existing Paypal Pro account, configure your IPN settings in Paypal so CiviCRM can receive updates on the recurring contributions in this manner:
+Once you have added the Recurring feature to your existing Paypal Pro account, configure your IPN settings in Paypal so CiviCRM can receive updates on the recurring contributions:
 
-* Log in to your Paypal account, click "Profile" in the top navigation
-* Look to the bottom of the page, click "Instant Payment Notification preferences"
-* Enter your URL for your `ipn.php` page where x is the payment processor id
-    * For Drupal: `http://example.org/civicrm/payment/ipn/x
-    * For Joomla: `http://example.org/administrator/components/com_civicrm/civicrm/payment/ipn/x
-    * For WordPress: `http://example.org/wp-content/plugins/civicrm/civicrm/payment/ipn/x
+* Follow the instructions here: [IPN Notify URL](/setup/payment-processors/recurring.md#IPN%20notify%20URL) to work out the correct URL to use.
+* Log in to your Paypal account, click "Profile" in the top navigation.
+* Look to the bottom of the page, click "Instant Payment Notification preferences".
+* Enter your URL for your IPN/Webhook where x is the payment processor id.
 
 !!! note
     You can re-send an IPN message from this area by using the IPN search. This is good if you have had it set to the wrong URL & want to resend them once you've fixed it
+
+!!! tip
+    If you are still using the deprecated https://example.com/civicrm/extern/ipn.php you should switch to the standard CiviCRM URL details can be found here: [IPN Notify URL](/setup/payment-processors/recurring.md#IPN%20notify%20URL)
 
 **Expected Behavior**
 

--- a/docs/setup/payment-processors/paypal-standard.md
+++ b/docs/setup/payment-processors/paypal-standard.md
@@ -62,7 +62,8 @@ CiviCRM can receive feedback from Paypal after the contribution is made. This re
 * Enter your CiviCRM site home page (e.g. [http://www.example.com](http://www.example.com/)) as the Notification URL. This is a placeholder. CiviContribute will pass the exact IPN 'listener' URL to PayPal automatically during each transaction.
 * Click Save
 
-Note: Recently we have introduced new improved (CMS independent and self-sufficient) IPN url in 4.7.12 and this does NOT mean that we have deprecated the old (extern) IPN. The new IPN - [http://www.example.com/civicrm/payment/ipn/2](http://www.example.com/civicrm/payment/ipn/2) where '2' is the Paypal Std. processor ID in CiviCRM.
+!!! tip
+    If you are still using the deprecated https://example.com/civicrm/extern/ipn.php you should switch to the standard CiviCRM URL details can be found here: [IPN Notify URL](/setup/payment-processors/recurring.md#IPN%20notify%20URL)
 
 #### Then Set the Auto Return So the Contributor Goes Back to Your Site
 

--- a/docs/setup/payment-processors/recurring.md
+++ b/docs/setup/payment-processors/recurring.md
@@ -1,0 +1,40 @@
+# Recurring Contributions and Webhooks
+
+## Overview
+Most payment processors that support recurring contributions use a "webhook" which is used by the payment processor
+to notify CiviCRM of each new payment, whether successful or failed.
+
+If webhooks are not setup correctly you may see one or more of the following symptoms in CiviCRM:
+* Payments not marked as "Completed".
+* New payments not recorded in CiviCRM.
+
+If you are not using recurring contributions the webhook is not normally required.
+
+## IPN notify URL
+!!! tip
+    Follow the instructions for the specific payment processor - when you get to the part where you need to configure the IPN notify URL / Webhook read below to work out what that URL should be.
+ 
+
+At this point, you need to figure out the "URL to be called" value. To do this, you need to check what ID is assigned to the Stripe payment processor in CiviCRM.
+
+To determine the ID, go back to CiviCRM and click `Administer -> System Settings -> Payment Processor`
+
+Click Edit next to the payment processor you are setting up.
+
+Then, check the Address bar. You should see something like the following:
+
+https://example.com/civicrm/admin/paymentProcessor?action=update&id=3&reset=1
+
+The end of the address contains id=3. That means that this Payment Processor id is 3.
+
+Therefore the call back address for your site will be:
+
+    civicrm/payment/ipn/3
+
+See below for the full address to add to the endpoint (replace NN with your actual ID number):
+
+* For Drupal:  https://example.com/civicrm/payment/ipn/NN
+* For Joomla:  https://example.com/?option=com_civicrm&task=civicrm/payment/ipn/NN
+* For Wordpress:  https://example.com/?page=CiviCRM&q=civicrm/payment/ipn/NN
+
+Typically, you only need to configure the end point to send live transactions and you want it to send all events.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ pages:
     - Deliverability: setup/civimail/deliverability.md
   - Payment processors:
     - Payment processors: setup/payment-processors/index.md
+    - Recurring Payments: setup/payment-processors/recurring.md
     - Authorize.net: setup/payment-processors/authorize-net.md
     - Card Access: setup/payment-processors/card-access.md
     - First Data: setup/payment-processors/first-data.md


### PR DESCRIPTION
This keeps on coming up on stackexchange / mattermost.  I've already documented the IPN URLs properly for the stripe extension (https://lab.civicrm.org/extensions/stripe/blob/master/docs/recur.md) so this is basically a copy of that documentation put in a shared location, and all docs for payment processors in this guide pointed to it instead of repeating the same thing, and getting it wrong in different ways!