### PR TITLE
Attempt to clarify the status of Drupal 8 support

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,10 +22,10 @@ See our page on [choosing a CMS](/planning/cms.md) for more information about th
 
 ### Drupal
 
-* Drupal 8 - Not yet supported
+* Drupal 8 - Not yet officially supported
 
     !!! bug "Work in progress"
-        CiviCRM functions with Drupal 8 but (as of October 2018) it has some unresolved issues, in particular [CRM-17652](https://issues.civicrm.org/jira/browse/CRM-17652).
+        CiviCRM functions with Drupal 8 but (as of October 2018) it has some minor bugs, and doesn't have an official release, relying instead on some unofficial tools and processes. See [the integration module](https://github.com/civicrm/civicrm-drupal-8/blob/master/README.md) for more information.
 
 * Drupal 7 - Compatible with CiviCRM 4.1 and higher.
 


### PR DESCRIPTION
The information about Drupal 8 isn't totally accurate. I think the most accurate description is something like, "it works, but isn't officially supported." The bug that's linked to also isn't very helpful: that bug is essentially resolved, but requires using some unofficial processes and tools.

So, this PR is an attempt to clarify things!

It links to the README.md in civicrm-drupal-8 under the assumption that this PR, https://github.com/civicrm/civicrm-drupal-8/pull/22, or some variation of it will get merged soon, and then that README can be where the docs about how to get Drupal 8 going can live.