### PR TITLE
Remove D6 DB URL from D7 docs.

### DIFF
--- a/docs/install/drupal7.md
+++ b/docs/install/drupal7.md
@@ -9,12 +9,6 @@
 
 You will need to know the database settings for your Drupal installation prior to running the CiviCRM installer: You can look up these values in your Drupal `settings.php` file (located by default in your `<drupal_root>/sites/default directory`) be looking for the following code:
 
-```
-$db_url = 'mysql://dbuser:dbpassword@localhost/drupal';
-```
-
-or
-
 ```php
 $databases = array (
   'default' =>


### PR DESCRIPTION
We say that Drupal 6 is deprecated, so let's not document it in the D7 DB setup docs; it'll only confuse people using D7 here IMO.