### PR TITLE
Remove EOL whitespace in .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ A documentation guide for people who install, upgrade, and maintain [CiviCRM](ht
 -   [Docs Publisher system and issue queue](https://lab.civicrm.org/documentation/docs-publisher)
 -   [Docs Book definitions for the Docs Publisher](https://lab.civicrm.org/documentation/docs-books)
 -   [Docs Working Group meta issue queue](https://lab.civicrm.org/documentation/meta)
- 
+

--- a/content-migration/new-content/requirements.md
+++ b/content-migration/new-content/requirements.md
@@ -16,21 +16,21 @@ A CMS, or Content Management System, is a type of application which controls the
 * Drupal 8 - Not yet supported
 
     !!! bug "Work in progress"
-        CiviCRM functions with Drupal 8 but (as of October 2017) it has some unresolved issues, in particular [CRM-17652](https://issues.civicrm.org/jira/browse/CRM-17652). 
- 
+        CiviCRM functions with Drupal 8 but (as of October 2017) it has some unresolved issues, in particular [CRM-17652](https://issues.civicrm.org/jira/browse/CRM-17652).
+
 * Drupal 7 - Compatible with CiviCRM 4.1 and higher.
 
-* Drupal 6 - No longer compatible (as of CiviCRM 4.3). It *might* work, but it's not supported. 
+* Drupal 6 - No longer compatible (as of CiviCRM 4.3). It *might* work, but it's not supported.
 
 ### WordPress
 
-WordPress 3.4.x or newer is required. 
+WordPress 3.4.x or newer is required.
 
 ### Joomla
 
 Joomla 2.5.x or 3.x.x is required.
 
-### Backdrop 
+### Backdrop
 
 Backdrop 1.0 or newer is required.
 
@@ -75,7 +75,7 @@ To install these extensions, you will typically install a separate package withi
 
 ### MySQL alternatives
 
-[MariaDB](https://mariadb.org/) and [Percona](https://www.percona.com/software/mysql-database/percona-server) are forks of the MySQL project and can mostly be used as drop-in replacements for MySQL. 
+[MariaDB](https://mariadb.org/) and [Percona](https://www.percona.com/software/mysql-database/percona-server) are forks of the MySQL project and can mostly be used as drop-in replacements for MySQL.
 
 Other database servers such as Postgres are not compatible with CiviCRM.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ This guide is for people installing, upgrading, and maintaining a [CiviCRM](http
 
 We also have a [User Guide](https://docs.civicrm.org/user/en/latest) which covers all the functionality available through CiviCRM's web-based interface.
 
-The two guides have some overlapping scope when it comes to setup and configuration. In general, we try to cover actions in the User Guide which the user can perform from within CiviCRM's user interface. Actions that require work outside of the CiviCRM interface (e.g. file-system or shell access) are covered in the System Administrator Guide. 
+The two guides have some overlapping scope when it comes to setup and configuration. In general, we try to cover actions in the User Guide which the user can perform from within CiviCRM's user interface. Actions that require work outside of the CiviCRM interface (e.g. file-system or shell access) are covered in the System Administrator Guide.
 
 ## Editing this guide
 

--- a/docs/install/backdrop.md
+++ b/docs/install/backdrop.md
@@ -63,7 +63,7 @@ The installer will verify that you've downloaded the correct version of CiviCRM,
 * Point your web browser to the following URL:
 
     `http://example.org/modules/civicrm/install/index.php?civicrm_install_type=backdrop`
-    
+   
 * You should see the **CiviCRM Installer** screen.
     * Initially, you will see a red bar with the message "These database details don't appear to be correct." This is expected as you haven't entered your database settings yet.
     * If you see other errors, check the **Requirements** details at the bottom of the page for more information. You will need to correct any issues before continuing.

--- a/docs/install/joomla.md
+++ b/docs/install/joomla.md
@@ -53,21 +53,21 @@ When CiviCRM is installed on top of an existing Joomla site, a special CiviCRM A
 * If the CiviCRM component does not install correctly (for example you get a blank screen instead of the confirmation page), delete the `~/components/com_civicrm` and `~/administrator/components/com_civicrm` and `~/media/civicrm directories` manually and then try each of the following before attempting to reinstall:
 
     * In your `php.ini` file or in `.htaccess` file in the Joomla root folder (if your server allows it), increase the `max_execution_time` to `600` and memory limit to more than 64M. Add the following to the `.htaccess` file in your Joomla root folder
-    
+   
         ```
         php_value memory_limit 128M
         php_value register_globals off
         php_value max_execution_time 600
         ```
-        
+       
         Or if you can't change the `.htaccess` file you can add a php.ini (or `.user.ini`) file in Joomla root folder or all directories, depending on your web server or hosting company.
-        
+       
         ```
         memory_limit = 128M
         register_globals = off
         max_execution_time = 600
         ```
-    
+   
     * CiviCRM is packaged with all the libraries (PEAR etc) that it uses. However a misconfigured or overly restrictive `open_basedir` directive on your web server might interfere with CiviCRM's ability to access some required files or directories. To turn `open_basedir` off, add this to your `vhost.conf` file: `php_admin_value open_basedir none` or ask your host to either turn it off or ensure that it is not preventing access to required directories (e.g. if you move configuration files or temp folders outside your web root). The configuration of sub domains might cause related issues: try installing in the main domain root or a sub folder instead.
 
 * If CiviCRM screens are not displaying properly and/or javascript widgets are not functioning, check your CiviCRM Resource URL (Administer >> System Settings >> Resource URLs). For Joomla installs, it should be something like: `http://example.org/administrator/components/com_civicrm/civicrm`

--- a/docs/install/wordpress.md
+++ b/docs/install/wordpress.md
@@ -24,14 +24,14 @@ All CiviCRM code and packages used by CiviCRM (such as PEAR libraries) are inclu
 * Create the `<wordpress path>/wp-content/plugins/files/` directory and ensure it is writable. CiviCRM for versions 4.6 and prior uses this directory for temporary and uploaded files.
 
     !!! information "Downloading Directly to Your Server with wget"
-    
+   
         If you have command-line access, you may prefer to download the zip file directly to your server using wget:
-        
+       
         1. Move into WordPress's plugin directory
             ```
             $ cd /var/www/wordpress/wp-content/plugins
             ```
-        
+       
         1. wget the file (modify this line to use the current zip file name for the version you want)
             ```
             wget https://download.civicrm.org/civicrm-x.x.x-wordpress.zip
@@ -44,7 +44,7 @@ All CiviCRM code and packages used by CiviCRM (such as PEAR libraries) are inclu
         ```
         $ cd /var/www/wordpress/wp-content/plugins
         ```
-    
+   
     1. Un-zip the file (modify this line with the actual downloaded filename)
         ```
         unzip civicrm_download_file.zip
@@ -61,14 +61,14 @@ Follow these steps to download and install the files that contain strings for la
 * Copy or ftp the tarball file to your WordPress installation's `/wp-content/plugins` directory. You may have to change the "File Permissions" setting of `/wp-content/plugins` directory to allow for "Write" Access. Just remember to change it back to default when done.
 
     !!! note "Downloading Directly to Your Server with wget"
-    
+   
         If you have command-line access, you may prefer to download the tarball file directly to your server using wget:
-        
+       
         1. Move into WordPress's modules directory and then into the civicrm subdirectory
             ```
             $ cd /var/www/wordpress/wp-content/plugins/civicrm
             ```
-        
+       
         1. wget the file (modify this line to use the current tarball file name for the version you want)
             ```
             $ wget https://download.civicrm.org/civicrm-x.x.xx-l10n.tar.gz
@@ -81,7 +81,7 @@ Follow these steps to download and install the files that contain strings for la
         ```
         $ cd /var/www/wordpress/wp-content/plugins/civicrm
         ```
-    
+   
     1. Un-tar the file (modify this line with the actual downloaded filename)
         ```
         $ tar -zxvf civicrm_download_file.tgz
@@ -100,13 +100,13 @@ The installer will verify that you've downloaded the correct version of CiviCRM,
 * Click the **Activate** link to activate the CiviCRM plugin.
 
 * Then go to Settings > CiviCRM Installer: `http://example.org/wp-admin/options-general.php?page=civicrm-install`
-    
+   
 * In version 4.7 and above you will see a link on the wp-admin page to the Installer screen
-    
+   
 * You should see the **CiviCRM Installer** screen.
 
     * If you see any errors, check the **Requirements** details at the bottom of the page for more information. You will need to correct any issues before continuing.
-    
+   
 * CiviCRM Database Settings.
 
     * Initially, the installer will default to using the existing WP database for the CiviCRM data.  You can change this if you want
@@ -141,8 +141,8 @@ Should an upgrade fail, you will need this backup copy to restore your site.
 
 * Starting in Version 5.13.x CiviCRM now can support "Clean URLs" for WordPress
 * By default CiviCRM URLs are in the format of https://example.org/civicrm?page=CiviCRM&q=civicrm/contribute/transact&reset=1&id=1 for a Contribution Page.  Enabling Cleaner URLs will enable URLs in the format of
-  * A Contribution Page will have the format of https://example.org/civicrm/contribute/transact/?reset=1&id=1  
-  * Profile Pages can be accessed at https://example.org/civicrm/profile/edit/?gid=1&reset=1 or https://wpcvrc.tadpole.cc/civicrm/profile/create/?gid=1&reset=1 
+  * A Contribution Page will have the format of https://example.org/civicrm/contribute/transact/?reset=1&id=1 
+  * Profile Pages can be accessed at https://example.org/civicrm/profile/edit/?gid=1&reset=1 or https://wpcvrc.tadpole.cc/civicrm/profile/create/?gid=1&reset=1
   * Listings would be at https://example.org/civicrm/profile/?gid=1&reset=1
   * The User's Contact Dashboard can be accessed at https://example.org/civicrm/user/?reset=1
 * To Enable Cleaner URLs , start by backing up your `Civicrm.settings.php` file as detailed in the "Locate and Backup the CiviCRM settings file" section above.

--- a/docs/misc/switch-cms.md
+++ b/docs/misc/switch-cms.md
@@ -2,7 +2,7 @@
 
 This section provides instructions for moving your CiviCRM installation from being installed within one CMS to being installed within another.  If you are changing server at the same time, please also refer to the instructions on [Moving an Existing Installation to a New Server or Location](/misc/switch-servers.md).
 
-The subpages in this section are named in the following "format": 
+The subpages in this section are named in the following "format":
 
 **Current CMS** to **New CMS**
 

--- a/docs/misc/switch-servers.md
+++ b/docs/misc/switch-servers.md
@@ -61,9 +61,9 @@ See below if you have a Drupal 8 composer installation, or other composer instal
         *** If copying an existing install don't skip the cache tables they will not be created automatically
         $ mysqldump -u mysql_username -p civicrm_db_name > civi_dump_file_name_of_your_choice.sql
         ```
-        
+       
         **mySQL Dump for Joomla**
-        
+       
         ```
         On the old server:
         $ mysqldump -u mysql_username -p --ignore-table=joomla_db_name.civicrm_domain \
@@ -80,30 +80,30 @@ See below if you have a Drupal 8 composer installation, or other composer instal
 
     1. Drupal: Again consider [Backup and Migrate Module](http://drupal.org/project/backup_migrate) to migrate the Drupal side.
     1. Command Line: _Substitute mysql_username, cms_db_name and dump_file_name_of_your_choice with appropriate values._**Load mySQL Dump for Drupal**
-    
+   
         ```
         On the new server:
         $ mysql -u mysql_username -p drupal_db_name < drupal_dump_file_name_of_your_choice.sql
         $ mysql -u mysql_username -p civicrm_db_name < civi_dump_file_name_of_your_choice.sql
         ```
-        
+       
         **Load mySQL Dump for Joomla**
-        
+       
         ```
         On the new server:
         $ mysql -u mysql_username -p joomla_db_name < dump_file_name_of_your_choice.sql
         ```
-    
+   
 !!! note
-    The above two steps, exporting the database from the source and importing to the target, 
+    The above two steps, exporting the database from the source and importing to the target,
     can also be performed in phpMyAdmin, although for exporting or importing a large database phpMyAdmin tends to time out
     and using command line is more reliable. The steps to export and import the database in phpMyAdmin are as follows:
     1. In the PHPMyAdmin interface, select your existing civiCRM database and then select the export feature.
     1. Under Export Method, select 'Quick' with format 'SQL.'
     1. Click the submit button to export your database which should then download somewhere onto your computer.
-    1. Import the data by navigating to the new website's PHPMyAdmin system and doing a simple, 
-    no frills import, using the data you just downloaded. The import should be into a new database created for CiviCRM 
-    (or an existing database which has been emptied by deleting all tables), with suitable permissions for the database user 
+    1. Import the data by navigating to the new website's PHPMyAdmin system and doing a simple,
+    no frills import, using the data you just downloaded. The import should be into a new database created for CiviCRM
+    (or an existing database which has been emptied by deleting all tables), with suitable permissions for the database user
     configured in the new sites civicrm.settings.php.
 
 1. Delete files with cached settings
@@ -114,7 +114,7 @@ See below if you have a Drupal 8 composer installation, or other composer instal
         * <drupal-root>/sites/default/files/civicrm/ConfigAndLog/Config.IDS.ini
         * <drupal-root>/sites/default/files/civicrm/ConfigAndLog/* (You can clear all the logs if you get an error about parsing XML)
         * <civicrm_custom_extension_folder>/cache/* (Only if you get errors after clearing the caches via the GUI) (See http://example.org/civicrm/admin/setting/path?reset=1 for location of custom extension folder)
-        
+       
     * Joomla:
 
         * <joomla-root>/media/civicrm/templates_c/*
@@ -127,7 +127,7 @@ See below if you have a Drupal 8 composer installation, or other composer instal
 
         * <wordpress-root>/wp-content/plugins/files/civicrm/templates_c/*
         * <wordpress-root>/wp-content/plugins/files/civicrm/ConfigAndLog/Config.IDS.ini
-        
+       
 1. Login to Drupal or to Joomla Administrator
 1. Re-enable the CiviCRM module and any other CiviCRM sub-modules.
 1. Enter the following URL in your browser to review and update directory paths and base URLs. See CiviCRM Menu: Administer >> System Settings >> Cleanup Caches and Update Paths
@@ -137,7 +137,7 @@ See below if you have a Drupal 8 composer installation, or other composer instal
     * Joomla 1.6 sites: http://example.org/administrator/index.php?option=com_civicrm&task=civicrm/admin/setting/updateConfigBackend&reset=1
     * WordPress sites: http://example.org/wp-admin/admin.php?page=CiviCRM&q=civicrm/admin/setting/updateConfigBackend&reset=1
         * Prior to 4.3.3 the WordPress implementation mistakenly drops everything after the domain in its suggestion for a new URL. The default location for a WordPress install relative to docroot would normally mean that the url should be http://example.org/wp-content/plugins/civicrm/civicrm/
-        
+       
 1. Review the recommended modified paths in the form - they should reflect the new Base Directory, Base URL, and Site name for CiviCRM.
     1. If these values do NOT look correct, then recheck the changes you made to civicrm.settings.php. If everything looks right in your civicrm.settings.php file, you may want to follow the directions for setting `config_backend` to `null` in the Troubleshooting section (below).
         * **Base Directory** - For Drupal installs, this is the absolute path to the location of the 'files' directory. For Joomla installs this is the absolute path to the location of the 'media' directory.

--- a/docs/planning/hosting.md
+++ b/docs/planning/hosting.md
@@ -72,7 +72,7 @@ CiviCRM. If they do not, there are two options available to you:
 
 ### Migrate to another host
 
-If your current host cannot accommodate CiviCRM you may want to consider migrating your CMS to a new host before installing CiviCRM. Depending on the CMS you are using, the process of moving from one host to another may be fairly straightforward. You are in a good position to transfer to another host if you can:  
+If your current host cannot accommodate CiviCRM you may want to consider migrating your CMS to a new host before installing CiviCRM. Depending on the CMS you are using, the process of moving from one host to another may be fairly straightforward. You are in a good position to transfer to another host if you can: 
 
 1.  request that your users **stop creating and updating content**
     during the migration,

--- a/docs/setup/backups.md
+++ b/docs/setup/backups.md
@@ -12,7 +12,7 @@ Your CiviCRM data is primarily stored in the MySQL database you've configured fo
     ```
     define( 'CIVICRM_DSN', 'mysql://db_user:user_passord@db_server/db_name?new_link=true' );
     ```
-    
+   
 If you use a hosting provider, they may be able to offer regular backups as part of your service. It is advisable to inquire as to the disaster contingency plans in place (redundancy, offsite / multiple location storage of backups, etc.).
 
 If you are setting up the backups yourself, there are a number of tool such as **mysqldump** or **phpMyAdmin** which can be used. Searching on _"mysql backup"_ will give you options and links to procedures.

--- a/docs/setup/cache.md
+++ b/docs/setup/cache.md
@@ -15,7 +15,7 @@ However, if you'd like to *improve the performance of the system*, you may insta
     ```
 
     With the default, pure-MySQL configuration, the mean response time was ~460ms.  With Redis, this decreased by ~60ms (~13%) to ~400ms.
-    
+   
     Note, though, the local copy of MySQL on this laptop is probably faster than a typical MySQL because it stores *everything* in ram-disk (rather than HDD or SSD). Compared to a typical, self-hosted MySQL, the Redis/Memcache advantage is probably wider.
 
 !!! note "What data (exactly) is stored where (exactly)?"
@@ -86,7 +86,7 @@ define('CIVICRM_DB_CACHE_PREFIX', 'example.com');
 
 ### Example: Redis and civibuild {:#config-redis-civibuild}
 
-If you are a developer using `civibuild` to manage several local dev sites, you can create one file `/etc/civicrm.settings.d/pre.d/100-cache.php` to activate Redis on all sites.  
+If you are a developer using `civibuild` to manage several local dev sites, you can create one file `/etc/civicrm.settings.d/pre.d/100-cache.php` to activate Redis on all sites. 
 
 ```php
 if (!defined('CIVICRM_TEST') || !(getenv('CIVICRM_UF') === 'UnitTests')) {

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -2,15 +2,15 @@
 
 ## CiviCRM system status
 
-Starting in 4.7, the CiviCRM System Status screen shows you a view of the current status of your CiviCRM installation. It is found at **Administer > Administration Console > System Status**. 
+Starting in 4.7, the CiviCRM System Status screen shows you a view of the current status of your CiviCRM installation. It is found at **Administer > Administration Console > System Status**.
 
 ![Screen Shot of CiviCRM System Status](/img/system-status.png)
 
 Items in *Red* need to be addressed as soon as possible. An item in red generally indicates something broken that will stop CiviCRM from working normally.
 
-Items in *Orange* should be addressed as soon as you can and may stop you from completing key CiviCRM tasks.  
+Items in *Orange* should be addressed as soon as you can and may stop you from completing key CiviCRM tasks. 
 
-Items in *Green* are set up correctly and are on the screen for information only.  
+Items in *Green* are set up correctly and are on the screen for information only. 
 
 ### Fixing issues
 

--- a/docs/setup/jobs.md
+++ b/docs/setup/jobs.md
@@ -4,14 +4,14 @@ This page provides instructions on setting up scheduled jobs to run automaticall
 
 !!! tip "More info in the User Guide"
     See the [scheduled jobs](https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs) page in the User Guide to learn more about how scheduled jobs work and why they are important.
-    
+   
 ## Process overview
 
-A typical CiviCRM installation uses the following process to execute scheduled jobs: 
+A typical CiviCRM installation uses the following process to execute scheduled jobs:
 
 1. A CiviCRM administrative user configures scheduled jobs via CiviCRM's UI.
 1. A cron job (outside of CiviCRM) executes CiviCRM's `Job.execute` API call regularly (e.g. every 5 minutes).
-1. The `Job.execute` API call runs all the configured scheduled jobs which are necessary at that point in time. 
+1. The `Job.execute` API call runs all the configured scheduled jobs which are necessary at that point in time.
 1. Each scheduled job executes its own API call (e.g. `Job.geocode`) and passes any parameters to this call as configured in the UI.
 
 ## Setup overview
@@ -21,7 +21,7 @@ To get scheduled jobs working you'll need to perform the following setup tasks:
 1. Configure and enable at least one scheduled job from within the UI. _([Instructions in the User Guide](https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs/#configuring))_
 
     * For example, a default job exists in new CiviCRM installations called "CiviCRM Update Check" which runs `Job.version_check`. This is an easy job to use while testing your schedule jobs setup. For the purposes of testing your setup, it will be helpful to modify the frequency of this job so that it runs every time cron runs.
-    
+   
 1. Manually execute your scheduled job from within the UI to ensure that it completes without error. View the job log if necessary. _([Instructions in the User Guide](https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs/#manual-execution))_
 
 1. Choose a method of executing the `Job.execute` API call from the command line. _([Instructions below](#choosing-a-method))_
@@ -31,11 +31,11 @@ To get scheduled jobs working you'll need to perform the following setup tasks:
 1. Set up a cron job to run the command regularly. _([Instructions below](#cron))_
 
     1. Test that your cron job works by viewing the job log after it should have run.
-    
+   
 1. Choose more scheduled jobs to enable to meet your needs. _([Instructions in the User Guide](https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs/#specific-jobs))_
 
 
-## Preparing 
+## Preparing
 
 ### Choosing a command {:#choosing-a-method}
 
@@ -61,7 +61,7 @@ Some of these methods require a valid username and password (for a CMS user who 
     * View all contacts
     * Access CiviCRM
     * Access CiviMail
-        
+       
 ## Commands to call `Job.execute` {:#commands}
 
 ### cv method {:#cv}
@@ -74,7 +74,7 @@ cv api job.execute --user=admin --cwd=/var/www/example.org
 
 Notes:
 
-* If `cv` only works when you run it from a shell and not from cron you may need to invoke it by calling it with an absolute path to php and to CV. 
+* If `cv` only works when you run it from a shell and not from cron you may need to invoke it by calling it with an absolute path to php and to CV.
 
 ```example
 /full/path/to/php /full/path/to/cv api job.execute --user=admin --cwd=/var/www/example.org
@@ -108,7 +108,7 @@ $ /path/to/wp-cli \
   civicrm api job.execute auth=0
 ```
 
-Notes: 
+Notes:
 
 * `wp-cli` only works for WordPress
 * See [wp-cli.org](http://wp-cli.org/) for more info about this tool.
@@ -141,7 +141,7 @@ You can use either the [REST interface](https://docs.civicrm.org/dev/en/latest/a
 The URL you need to call depends on the CMS you are using.  In the examples below, replace `<cron-url>` with one of the following (using `http` or `https` as appropriate).
 
 * Drupal:
-    
+   
     ```
     https://example.org/sites/all/modules/civicrm/bin/cron.php
     ```
@@ -157,7 +157,7 @@ The URL you need to call depends on the CMS you are using.  In the examples belo
     ```
     https://example.org/<CONTENT-DIR>/plugins/civicrm/civicrm/bin/cron.php
     ```
-    
+   
     (Make sure to replace `<CONTENT-DIR>` with your own value.)
 
 #### Parameters to pass to `cron.php`
@@ -183,13 +183,13 @@ $ wget -O - -q -t 1 '<cron-url>?name=<username>&pass=<password>&key=<site-key>'
 Use `wget` to send queued CiviMail mailings:
 
 1. Create a file named `civicrm-wgetrc` that contains this line:
-    
+   
     ```
     post-data=name=<username>&pass=<password>&key=<site-key>&job=process_mailing
     ```
 
 1. Create a script that contains these lines:
-    
+   
     ```bash
     export WGETRC=civicrm-wgetrc
     wget -O - -q -t 1 <cron-url>
@@ -233,8 +233,8 @@ Check the [curl documentation](http://curl.haxx.se/docs/) for information about 
 In order for the scheduled jobs configured within the CiviCRM UI to run automatically, you'll need to configure a cron job which executes the `Job.execute` API call.
 
 !!! note
-    The System Status screen `/civicrm/a#/status` will only report "Cron running OK" if your cron job invokes `Job.execute`. The System Status page will complain that cron is "not running" if your cron only invokes particular jobs such as `process_mailing` or `fetch_bounces`. 
-    
+    The System Status screen `/civicrm/a#/status` will only report "Cron running OK" if your cron job invokes `Job.execute`. The System Status page will complain that cron is "not running" if your cron only invokes particular jobs such as `process_mailing` or `fetch_bounces`.
+   
 ### crontab {:#crontab}
 
 1. Make sure you have chosen (and tested) one of the [commands to call `Job.execute`](#commands). In the following examples, we will refer to your command as `<command>`.
@@ -244,12 +244,12 @@ In order for the scheduled jobs configured within the CiviCRM UI to run automati
     $ crontab -e
     ```
 
-1. Place the following line in your crontab to run your command every 5 minutes. 
+1. Place the following line in your crontab to run your command every 5 minutes.
 
     ```
     */5 * * * * <command>
     ```
-    
+   
 ### webcron
 
 Another way to set up your cron job is to use a webcron like [easycron](https://www.easycron.com).
@@ -276,13 +276,13 @@ If you are using the [Aegir](http://www.aegirproject.org) hosting environment, w
 
 ## Running specific jobs via cron {:#specific-jobs-via-cron}
 
-In the [commands](#commands) section above, we describe the various methods for executing the `Job.execute` API call, which in turn runs all the scheduled jobs necessary at that moment. 
+In the [commands](#commands) section above, we describe the various methods for executing the `Job.execute` API call, which in turn runs all the scheduled jobs necessary at that moment.
 
 But if you want more control over the scheduling of your jobs you can use software like [crontab](#cronb) to execute specific jobs. For example, maybe you want to run `Job.mail_report` on the first Monday of the month. CiviCRM's Scheduled Jobs interface does not allow this level of granularity and control.
 
 With all of the commands above, you can replace `Job.execute` with the API of the job of your choosing. Refer to the [list of all jobs](https://docs.civicrm.org/user/en/latest/initial-set-up/scheduled-jobs/#specific-jobs) in the User Guide to find the right API call.
 
-When using `cron.php` you can only execute API from "job" entity. This means that if an extension has defined an API action like `Foo.process` you won't be able to call this action from `cron.php` because its entity is `Foo` instead of `Job`. 
+When using `cron.php` you can only execute API from "job" entity. This means that if an extension has defined an API action like `Foo.process` you won't be able to call this action from `cron.php` because its entity is `Foo` instead of `Job`.
 
 ## Troubleshooting
 

--- a/docs/setup/logging.md
+++ b/docs/setup/logging.md
@@ -55,7 +55,7 @@ In some testing there hasn't been any indication of any significant performance 
            'mysql://user:pass@localhost/db_name?new_link=true'
         );
         ```
-        
+       
 1. Go to **Administer › System Settings - Misc (Undelete, PDFs, Limits, Logging, Captcha, etc.)**
 
 1. Set Logging to **Yes**.
@@ -95,7 +95,7 @@ Sites that wish to revert to ARCHIVE would need to do that through mysql - there
 
 1. Go to **Administer > CiviReport > Create New Report From Template**.
 
-1. With logging turned on, two new report templates are available: 
+1. With logging turned on, two new report templates are available:
     * Contact Logging Report (Summary)
     * Contact Logging Report (Detail)
 

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -49,7 +49,7 @@ using routes the user to external pages for payment processing
 (e.g. PayPal Standard redirects users to PayPal pages to make the
 transaction before returning to your website) the risks are fairly low.
 However you should still be compliant, which involves completing a Self Assessment Questionnaire (SAQ),
-usually SAQ A, covering some technical points which go beyond using SSL 
+usually SAQ A, covering some technical points which go beyond using SSL
 to secure your site, and just as importantly, covering good security practices in the way
 your organization is run.
 
@@ -59,7 +59,7 @@ of the way you manage both human and technical security risks,
 and you may need to engage a qualified assessor to help you meet a sufficient standard.
 The PCI Security Standards Council publishes [a table](https://www.pcisecuritystandards.org/pci_security/completing_self_assessment)
 for guidance about which level of compliance you require.
-Consider the payment processing method you intend to use carefully before 
+Consider the payment processing method you intend to use carefully before
 implementing it, and seek security consultation if you
 decide to store credit card information on your server (this is not
 recommended for smaller organizations because compliance is expensive).
@@ -98,7 +98,7 @@ If you have a public-facing website, note that when switching traffic from (for 
 
 ## Backups and their security
 
-Hackers are as likely to steal data from backups as from production sites. 
+Hackers are as likely to steal data from backups as from production sites.
 The security of backups is covered on the [backups page of this guide](/sysadmin/en/latest/setup/backups/).
 
 ## Data storage jurisdiction
@@ -125,10 +125,10 @@ examined:
     passwords are of a sufficient complexity and length (e.g. minimum 8
     characters, including letters and numbers), and must not be shared
     or divulged over insecure communications like email.
-    
+   
 !!! note
-    CiviCRM implements PHPIDS, which checks the content of fields users are trying to save, and either prevents them being saved, 
-    or logs them, if they are suspected of being malicious. There is a little more detail in 
+    CiviCRM implements PHPIDS, which checks the content of fields users are trying to save, and either prevents them being saved,
+    or logs them, if they are suspected of being malicious. There is a little more detail in
     [the section on PHPIDS in the Developer Guide](https://docs.civicrm.org/dev/en/latest/security/inputs/#phpids).
 
 ## Filesystem permissions
@@ -136,13 +136,13 @@ examined:
 !!! tip
     There is a [detailed post on Stack Exchange about CiviCRM file permissions]
     (https://civicrm.stackexchange.com/questions/168/are-there-recommended-directory-ownership-and-permission-settings-for-civicrm-fi#answer-11640). In particular it points out that allowing the code to be writable by the web server
-    greatly increases the risk of a hack. However, if the directories in the file system containing PHP code are not writable by the 
-    web server, then installation of extensions via the browser UI may fail (as will updates of the CMS 
+    greatly increases the risk of a hack. However, if the directories in the file system containing PHP code are not writable by the
+    web server, then installation of extensions via the browser UI may fail (as will updates of the CMS
     via the browser, such as WordPress offers). Besides, on shared hosting it may not
-    be possible to make the codebase unwritable. In short, if the hosting allows you to make your codebase unwritable, and 
-    losing the possibility of updating or installation of extensions via the browser is acceptable, 
+    be possible to make the codebase unwritable. In short, if the hosting allows you to make your codebase unwritable, and
+    losing the possibility of updating or installation of extensions via the browser is acceptable,
     then doing so offers a considerable improvement in security.
-    
+   
 ### Directories should not be browsable
 
 In its default configuration, CiviCRM places some uploaded and server-generated data in the CMS's data folder (such as Drupal's "sites/default/files" or Joomla's "media"). This folder is web-accessible, but many of the documents processed by CiviCRM should not be web-accessible. If CiviCRM's data folders are not suitably protected from web access, then sensitive information may be disclosed.

--- a/docs/setup/site-key.md
+++ b/docs/setup/site-key.md
@@ -5,9 +5,9 @@ If you are triggering jobs using the URL method, you must manually generate a si
 1. First generate the key. We recommend using a 16-32 bit alphanumeric/punctuation key value.
 
     !!! warning
-    
+   
         Make sure there that there are no reserved or unsafe URL characters in your site key. These include spaces and the following characters:
-        
+       
         ```
         & = + $ ? % , / : { } # | '
         ```
@@ -20,18 +20,18 @@ If you are triggering jobs using the URL method, you must manually generate a si
         ```
 
 1. Open your settings file - `civicrm.settings.php` - in your favorite editor and either add or edit the `CIVICRM_SITE_KEY` value.
-    
+   
     * **in Drupal** , `civicrm.settings.php` is located in `/sites/default`.
-    
+   
     * **in Joomla,** there are 2 `civicrm.settings.php` files. By default these are located in `site/administrator/components/com_civicrm` and `site/components/com_civicrm` - it's important to add the same key to both files as some Joomla front-end functions rely on the key (eg, decrypting the Outbound Mail SMTP Password).
-    
+   
     * **in WordPress** , `civicrm.settings.php` is located in : For versions 4.6 and Prior `/wp-content/plugins/civicrm`. Starting in 4.7 for new installs `CONTENT-DIR/uploads/civicrm`
 
 1. Depending on which version of CiviCRM you've installed, you may have this setting in your file already with a value of `NULL`, or you may need to add the line. In either case, replace `NULL` with the value of your key.
-    
+   
     !!! success "Example"
         If my generated site key value is: `3cx4aNkpQwxmM1hTMV~!B09iO6` then my settings file should look like this:
-    
+   
         ```
         define( 'CIVICRM_SITE_KEY', '3cx4aNkpQwxmM1hTMV~!B09iO6' );
         ```

--- a/docs/upgrade/backdrop.md
+++ b/docs/upgrade/backdrop.md
@@ -11,7 +11,7 @@ Use this document to upgrade CiviCRM installations on Backdrop CMS to the latest
 1. Select the latest currently available CiviCRM tarball for Backdrop.
 
     Example: `civicrm-x.x.x-backdrop.tar.gz`
-    
+   
 1. Save this file in `<backdrop_root>/modules`.
 
 If using localization, also download the latest version of the localization files. See the [CiviCRM Localisation](https://wiki.civicrm.org/confluence/display/CRMDOC/i18n+Administrator%27s+Guide%3A+Using+CiviCRM+in+your+own+language) page about how to install files for running CiviCRM in languages other than American English.
@@ -92,18 +92,18 @@ Choose one of the following methods:
 * Run the following `drush` command from within your site:
 
     ```bash
-    $ drush civicrm-upgrade-db 
+    $ drush civicrm-upgrade-db
     ```
 
 * Or, point your web browser to the following URL and follow the on-screen instructions.
-    
+   
     ```
     http://example.org/civicrm/upgrade?reset=1
     ```
-    
+   
     !!! note
         This page loads on a Backdrop maintenance page. If you use a custom `maintenance.tpl.php` file you may wish to temporarily disable that file and use Backdrop's default.
-    
+   
 
 ## Clean up
 

--- a/docs/upgrade/drupal7.md
+++ b/docs/upgrade/drupal7.md
@@ -11,7 +11,7 @@ Use this document to upgrade CiviCRM installations on Drupal 7 to the latest Civ
 1. Select the latest currently available CiviCRM tarball for Drupal.
 
     Example: `civicrm-x.x.x-drupal.tar.gz`
-    
+   
 1. Save this file in `<drupal_root>/sites/all/modules`.
 
 If using localization, also download the latest version of the localization files. See the [CiviCRM Localisation](https://wiki.civicrm.org/confluence/display/CRMDOC/i18n+Administrator%27s+Guide%3A+Using+CiviCRM+in+your+own+language) page about how to install files for running CiviCRM in languages other than American English.
@@ -25,7 +25,7 @@ When upgrading a production site, it is recommended that you take your site offl
 
 !!! warning
     Sometimes Drupal modules, paticularly those which integrate with CiviCRM, are not compatible with the latest version of CiviCRM. In this case the update to CiviCRM may trigger errors. Although this problem is rare, unless you are confident and about handling such errors, the safest workflow is to disable all Drupal modules which integrate with CiviCRM before performing the upgrade, and to re-enable them after the upgrade is complete.
-    
+   
 ## Upgrade the filesystem
 
 ### Delete all previous version code files
@@ -71,30 +71,30 @@ Choose one of the following methods:
 * Run the following `drush` command from within your site:
 
     ```bash
-    $ drush civicrm-upgrade-db 
+    $ drush civicrm-upgrade-db
     ```
-    
+   
 * Or, point your web browser to the following URL and follow the on-screen instructions.
-    
+   
     ```
     http://example.org/civicrm/upgrade?reset=1
     ```
-    
+   
 * Or, run the following `cv` command from within your site:
 
     ```bash
-    $ cv upgrade:db 
+    $ cv upgrade:db
     ```
-    
+   
 !!! note
-    The `cv upgrade:db` command accepts a --dry-run option to show what changes will be made before committing them to the database. 
+    The `cv upgrade:db` command accepts a --dry-run option to show what changes will be made before committing them to the database.
     For the maximum level of verbosity use `cv upgrade:db --dry-run -vv`.
-    
+   
 
 ## Clear cached files¶
 
 Delete all files in sites/default/files/civicrm/templates_c/, or clear the caches using one of the command line tools, such s `cv flush` or `drush cache-clear civicrm`.
 
-    
+   
 !!! note
     If you disabled modules, or placed the site in maintenance mode, remember to reverse those steps after the upgrade.

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -83,7 +83,7 @@ For each version upgrade you perform, follow these steps to merge your template 
     For each of these templates with conflicting changes, perform the remaining steps.
 
     !!! note
-        Each message template has _two_ separate pieces of text &mdash; the HTML version and the text version. Take note of conflicting changes to each of these types, as you'll need to process them separately.   
+        Each message template has _two_ separate pieces of text &mdash; the HTML version and the text version. Take note of conflicting changes to each of these types, as you'll need to process them separately.  
 
 1. Let's pause here and explain a little theory...
 

--- a/docs/upgrade/joomla.md
+++ b/docs/upgrade/joomla.md
@@ -30,13 +30,13 @@ The ["Before upgrading"](/upgrade/index.md#before-upgrading) steps describe step
 
 * `<joomla_root>/components/com_civicrm/civicrm.settings.php`
 * `<joomla_root>/administrator/components/com_civicrm/civicrm.settings.php`
-    
+   
 Copy these files to a location outside your Joomla project.
 
 ## Install the Extension
 
 1. Login to your Joomla Administrator site.
-1. From the menu choose Extensions » Manage » Install 
+1. From the menu choose Extensions » Manage » Install
 1. Use the **Install from Folder** tab and enter the full path to the un-zipped **com_civicrm** directory, which should be something like **JOOMLA.x_ROOT/tmp/com_civicrm**. If your temp directory is configured correctly you should only need to add "com_civicrm" to the prepopulated path.
 1. You should see "CiviCRM successfully installed" message.
 

--- a/docs/upgrade/version-specific.md
+++ b/docs/upgrade/version-specific.md
@@ -4,7 +4,7 @@ In general the steps to upgrade CiviCRM are identical no matter which version yo
 
 Here you will find special steps needed when your upgrade crosses certain CiviCRM versions.
 
-For example, if you are upgrading from CiviCRM 4.1 to CiviCRM 4.3, then you should check this page for *both* "CiviCRM 4.2" and "CiviCRM 4.3" since your upgrade "crosses" both of those versions. 
+For example, if you are upgrading from CiviCRM 4.1 to CiviCRM 4.3, then you should check this page for *both* "CiviCRM 4.2" and "CiviCRM 4.3" since your upgrade "crosses" both of those versions.
 
 ## CiviCRM 5.0
 

--- a/docs/upgrade/wordpress.md
+++ b/docs/upgrade/wordpress.md
@@ -11,7 +11,7 @@ Use this document to upgrade CiviCRM installations on WordPress to the latest Ci
 1. Select the latest currently available CiviCRM tarball for WordPress.
 
     Example: `civicrm-x.x.x-wordpress.zip`
-    
+   
 1. Save this file in `<wordpress_root>/wp-content/plugins/`.
 
 If using localization, also download the latest version of the localization files. See the [CiviCRM Localisation](https://wiki.civicrm.org/confluence/display/CRMDOC/i18n+Administrator%27s+Guide%3A+Using+CiviCRM+in+your+own+language) page about how to install files for running CiviCRM in languages other than American English.
@@ -34,7 +34,7 @@ The ["Before upgrading"](/upgrade/index.md#before-upgrading) steps describe step
     `<wordpress_root>/content-dir/uploads/civicrm/civicrm.settings.php`
 
     *The installer in 4.7 and above does not assume that the content-dir is wp-content. It probably is, but can be renamed/moved as detailed [here](https://codex.wordpress.org/Editing_wp-config.php#Moving_wp-content_folder)*
-    
+   
 1. Copy this file to a location outside your WordPress project. You may need to restore it after upgrading.
 1. Also, if you are using the `<wordpress_root>/wp-content/plugins/civicrm/civicrm/settings_location.php` file in your implementation, make a copy of this as well as you will need to restore it after upgrading.
 
@@ -100,9 +100,9 @@ If you don't have SSH access and your IP panel does not recognize tar files, you
 
 Delete all files in your `templates_c` directory
 
-* In CiviCRM 4.7 and above: 
+* In CiviCRM 4.7 and above:
     `<wordpress_root>/<content-dir>/uploads/civicrm/templates_c`
-    
+   
 !!! caution "For CiviCRM 4.6 and older:"
     `<wordpress_root>/<content-dir>/plugins/files/civicrm/templates_c`
 
@@ -118,7 +118,7 @@ Delete all files in your `templates_c` directory
 1. If you are ready to upgrade, click the **Upgrade Now** button.
 1. You should see the message **Upgrade successful** when the upgrade completes.
     * If you receive any errors during the process, please note down the exact error message, and check for solutions on [Stack Exchange](https://civicrm.stackexchange.com/) or [Mattermost](https://chat.civicrm.org).
-    
+   
 1. Now click the **Return to CiviCRM home page** link. This will rebuild CiviCRM menus automatically and return you to the CiviCRM home dashboard.
 
 


### PR DESCRIPTION
Some $EDITORs tidy up whitespace on save, which can lead to unrelated tidy-up appearing in commits.

To avoid this "noise", submitting an MR that does this for all current md files.

Done with:
```
perl -pi -e 's#(^.*)[ \t]+$#$1#g' *md */*md */*/*md
```