### PR TITLE
Added fix info about Salient Theme

### DIFF
--- a/docs/integration/wordpress/incompatibilities.md
+++ b/docs/integration/wordpress/incompatibilities.md
@@ -123,7 +123,7 @@ cv: 4.5 
     Causes conflict with Backbone JQuery calls, mainly noticed in Events -> Manage -> Online Registration
     
 * Workaround:  
-* Other comments:  
+* Other comments:  Fixed somewhere around 4.7.29.
 
 ## LDD Directory  Lite
 


### PR DESCRIPTION
Not sure the best way to handle this, but it's no longer a problem.  I have a feeling that most, if not all, of the Backbone JQuery call issues listed on the page were fixed at the same time.  As stated, I believe this was around the 4.7.29 release.