### PR TITLE
dev/wordpress#66 - Document transition for `wp-content/plugins/files/civicrm`

### DIFF
--- a/docs/upgrade/version-specific.md
+++ b/docs/upgrade/version-specific.md
@@ -8,12 +8,11 @@ For example, if you are upgrading from CiviCRM 4.1 to CiviCRM 4.3, then you shou
 
 ## CiviCRM 5.29
 
-### WordPress and "plugins/files/civicrm"
+### WordPress and "wp-content/plugins/files/civicrm"
 
 The CiviCRM "files" folder (a.k.a.  `[civicrm.files]`) stores runtime data, such as uploaded images, log files, and
 certain caches.  The folder is created automatically during installation.  However, the default location of this folder
-has evolved.  Deployments which originated on CiviCRM-WordPress circa 4.x should perform a manual update to handle this
-evolution.
+has evolved, and some systems require a manual update.
 
 !!! note "How has the folder changed?"
 
@@ -21,87 +20,87 @@ evolution.
 
     | Version | Typical location |
     | -- | -- |
-    | CiviCRM 4.x | `wp-content/plugins/files/civicrm` |
-    | CiviCRM 5.x | `wp-content/uploads/civicrm` |
+    | CiviCRM 4.x | `{webroot}/wp-content/plugins/files/civicrm` |
+    | CiviCRM 5.x | `{webroot}/wp-content/uploads/civicrm` |
 
     Additionally, there is an evolution in *how* the location is typically calculated:
 
     | Version | How the location is typically calculated |
     | -- | -- |
-    | CiviCRM 4.x | Relative to `CIVICRM_TEMPLATE_COMPILEDIR` |
-    | CiviCRM 5.x (before 5.29) | Relative to `CIVICRM_TEMPLATE_COMPILEDIR` |
-    | CiviCRM 5.x (after 5.29) | Relative to `wp_get_upload_dir()` |
+    | CiviCRM 4.x | Start from `CIVICRM_TEMPLATE_COMPILEDIR` and go to the parent folder |
+    | CiviCRM 5.x (before 5.29) | Start from `CIVICRM_TEMPLATE_COMPILEDIR` and go to the parent folder|
+    | CiviCRM 5.x (after 5.29) | Start from `wp_get_upload_dir()` and go to child folder, `civicrm/` |
 
 !!! note "Why has the location evolved?"
 
     The original location did not match the WordPress convention for runtime data-storage.  This can create
-    compatibility and installation problems for some hosting environments and configurations that depend on the
-    WordPress conventions.  Using a more standardized location (and more standardized calculation) ultimately
-    simplifies administration and improves compatibility.
+    compatibility and installation problems for some hosting environments that depend on the WordPress conventions. 
+    Using a more standardized location (and more standardized calculation) ultimately simplifies administration and
+    improves compatibility.
 
 !!! note "How do I know what my current location is?"
 
-    There are a few techniques you may use:
+    There are a few techniques:
 
     * Look in your web filesystem for the folder (ie `wp-content/plugins/files/civicrm` or `wp-content/uploads/civicrm`).
       One or the other should exist.
-    * Login to CiviCRM and navigate to `Administer => System Settings => Directories`. Click on the help ("?") icon.
-      Then navigate to `Administer => System Settings => Resource URLs`. Click on the help ("?") icon.
+    * Login to CiviCRM and navigate to `Administer => System Settings => Directories`. Click on the help ("?") icon at the
+      top; a dialog will define `[civirm.files]`.  Similarly, navigate to `Administer => System Settings => Resource
+      URLs`.  Click on the help ("?") icon; a dialog will define `[civicrm.files]`.
 
-The evolution improves compatibility for new installations, but it poses a challenge for upgrades and maintenance: it
-grows increasingly complex to verify backward-compatibility.  v5.29 may break backward-compatibility for some
-deployments.
+If a site currently uses `wp-content/plugins/files/civicrm`, then you should prepare in advance for 5.29 -- either by
+(1) configuring the folder explicitly or (2) migrating the folder.  Below, we describe each approach and some trade-offs.
 
-There are two ways to prepare for v5.29 and avoid upgrade problems -- set the folder explicitly, or migrate the folder.
+!!! tip "Approach 1: Configure the folder explicitly"
 
-!!! tip "Approach 1: Set the folder explicitly"
+    By default, CiviCRM calculates the location of `[civicrm.files]` automatically.  However, you
+    can [explicitly set the location of `[civicrm.files]`](../customize/paths.md) to match your
+    actual, current location.  Any future changes in the defaults will not affect your configuration.
 
-    By default, CiviCRM calculates the location of `[civicrm.files]` implicitly.  However, if the default calculation
-    is not reliable for your environment, you can override it.  Set the explicit location of `[civicrm.files]` to match
-    your actual, current location:
+    Steps:
 
     1. Determine the local path of the current folder (ex: `/var/www/wp-content/plugins/files/civicrm`)
     2. Determine the public URL of the current folder (ex: `https://example.com/wp-content/plugins/files/civicrm`)
-    3. Find and edit the file `civicrm.settings.php`. Specify:
+    3. Find and edit the file `civicrm.settings.php`. Add these options:
 
        ```php
        $civicrm_paths['civicrm.files']['path'] = '/var/www/wp-content/plugins/files/civicrm';
        $civicrm_paths['civicrm.files']['url'] = 'https://example.com/wp-content/plugins/files/civicrm';
        ```
 
-    The advantage of this approach is that you get full compatibility with little change.
+    The advantage of this approach is that the change is relatively safe, clear-cut, and easy to undo.
 
-    The disadvantage: if you ever migrate to a different hosting environment (or if you use a staging<=>production
+    The disadvantage: if you ever migrate the site to a different hosting environment (or if you use a staging<=>production
     process), you will need to update `civicrm.settings.php` to use the new paths and new URLs.
 
 !!! tip "Approach 2: Migrate the folder"
 
-    You may reorganize your files to match the newer defaults. Steps:
+    You may reorganize the files to match the newer defaults. Initial steps:
 
     1. Rename the folder `wp-content/plugins/files/civicrm` to `wp-content/uploads/civicrm`.
     2. In CiviCRM, navigate to `Administer => System Settings => Directories`. If there are any explicit
        references to the old folder, change them.
     3. In CiviCRM, navigate to `Administer => System Settings => Resource URLs`. If there are any explicit
        references to the old folder, change them.
-    4. Find and edit the `civicrm.settings.php`. Change the `CIVICRM_TEMPLATE_COMPILEDIR` to use the new location.
-    5. Modify or redirect any URLs or scripts which reference the older location.
-           * Examples to consider:
-               * Email templates which use images that were previously uploaded
-               * Contact records with photo attachments
-               * External links to assets in downloaded extensions
-               * Backup tools and logging tools which collect information from this folder
-           * Possible techniques:
-               * Directly change the references
-               * Create a symlink between the old/new locations
-               * Configure the HTTP server
+    4. Find and edit the `civicrm.settings.php`. Search for any references to `plugins/files/civicrm`
+       and change them to `uploads/civicrm`.
 
-    The advantage of this is that your configuration will be more "portable" - e.g. you can more easily migrate
-    data between staging and production systems.
+    At this point, the folder has been formally moved - but we may not be done yet. There may still be
+    external references to the old URLs or the old paths, such as:
 
-    The disadvantage: finding and correcting old URLs is an open-ended, subjective task. The difficulty of this
-    task depends on both how the system is used (*e.g. Have users uploaded any images?*) and how the system
-    is hosted (*e.g. Does it run on Linux or Windows? Apache or nginx? etc*)
+    * Email templates which use images that were previously uploaded
+    * Contact records with photo attachments
+    * External links to assets in downloaded extensions
+    * Backup tools and logging tools which collect information from the old folder
 
+    How to address old references?  If your hosting environment supports "symlinks", you might create a symlink from
+    the old folder to the new folder.  Alternatively, you might configure the HTTP server to do redirects, or you might
+    do a global search/replace on MySQL content. Alas, the prognosis and details of these measures will depend
+    on the specific deployment (*e.g.  Does it run on Linux or Windows?  Apache or nginx?  etc*) and on how the
+    system was used (*e.g. Have users uploaded any images? Where are the old references?*)
+
+    The advantage of this approach is that the configuration will be more "portable" - e.g.  you can more easily
+    migrate, reproduce, or reconfigure the site for different environments.
 
 ## CiviCRM 5.0
 

--- a/docs/upgrade/version-specific.md
+++ b/docs/upgrade/version-specific.md
@@ -33,10 +33,10 @@ has evolved, and some systems require a manual update.
 !!! note "Which systems are OK? Which systems have a problem?"
 
     On many CiviCRM-WordPress deployments, the new rule and the old rule agree - they both output
-    `...uploads/civicrm/`.  These deployments are OK.
+    `wp-content/uploads/civicrm/`.  These deployments are OK.
 
     However, on some deployments, the new rule and old rule may not agree. This is likely to happen if the site
-    originated on v4.6 or if the path has `...plugins/files/civicrm/`. These sites require some extra maintenance.
+    originated on v4.6 or if the path has `wp-content/plugins/files/civicrm/`. These sites require some extra maintenance.
 
 !!! note "Why has the location evolved?"
 
@@ -44,25 +44,42 @@ has evolved, and some systems require a manual update.
     configurations, this created compatibility or installation problems.  With the changes in 4.7 and 5.29, CiviCRM is
     better aligned with the convention - leading to better compatibility.
 
-!!! note "How do I know what my current location is?"
+!!! note "How do I know what the true location is?"
 
-    There are a few techniques:
+    Look in the filesystem to determine where there is actual data. In particular, look at both:
 
-    * Look in your web filesystem for the folder (ie `wp-content/plugins/files/civicrm` or `wp-content/uploads/civicrm`).
-      One or the other should exist.
-    * Login to CiviCRM and navigate to `Administer => System Settings => Directories`. Click on the help ("?") icon at the
-      top; a dialog will define `[civirm.files]`.  Similarly, navigate to `Administer => System Settings => Resource
-      URLs`.  Click on the help ("?") icon; a dialog will define `[civicrm.files]`.
+    * `wp-content/plugins/files/civicrm`
+    * `wp-content/uploads/civicrm`
 
-If a site currently uses `{WEB_ROOT}/wp-content/plugins/files/civicrm`, then you should prepare in advance for 5.29. 
-The most clear-cut resolution is to configure the folder explicitly.  Alternatively, you may migrate the folder to the
-newer location.  Below, we describe each approach and some trade-offs.
+    If only one folder exists, then that's it.
+
+!!! note "What if both folders exist?"
+
+    This has been observed in some scenarios - e.g.  if you attempted an upgrade to certain versions of CiviCRM without
+    laying groundwork from this guide, then CiviCRM may have auto-created a second set of placeholder folders.
+
+    The best thing is to dig into the filesystem and confirm whether *real content* exists in the subfolders.
+
+    * Important content can live in the subfolders `custom/`, `ext/`, `persist/contribute/`, and `upload/`.
+    * You can disregard any empty folders or any placeholder files (`.htaccess`, `index.html`).
+    * You can disregard `templates_c` or `dyn`. These are auto-generated and disposable.
+    * On the command-line, the commands `find`, `find -type f`, and `du` can help to locate content.
+
+    If the only genuine content is in `wp-content/plugins/files/civicrm`, then proceed with that.
+
+    If you cannot determine the one true location, then you may wish to discuss the details on Mattermost (`WordPress`) or StackExchange.
+
+Manual intervention is appropriate if the true content lives in `{WEB_ROOT}/wp-content/plugins/files/civicrm`. These
+steps will ensure that the content continues to be available in 5.29.
+
+The most clear-cut resolution is to configure the folder explicitly.  Alternatively, you may migrate or merge the
+folder into the newer location.  Below, we describe each approach and some trade-offs.
 
 !!! tip "Approach 1: Configure the folder explicitly"
 
     The aim of this approach is to preserve the original location of `[civicrm.files]`.  If there are any external
     references to the original location (such as hyperlinks or backup tools), they will continue to work.  We can
-    achive this by [explicitly setting the location in `civicrm.settings.php`](../customize/paths.md).  It will not
+    achieve this by [explicitly setting the location in `civicrm.settings.php`](../customize/paths.md).  It will not
     matter if the default values change.
 
     Steps:

--- a/docs/upgrade/version-specific.md
+++ b/docs/upgrade/version-specific.md
@@ -6,6 +6,103 @@ Here you will find special steps needed when your upgrade crosses certain CiviCR
 
 For example, if you are upgrading from CiviCRM 4.1 to CiviCRM 4.3, then you should check this page for *both* "CiviCRM 4.2" and "CiviCRM 4.3" since your upgrade "crosses" both of those versions.
 
+## CiviCRM 5.29
+
+### WordPress and "plugins/files/civicrm"
+
+The CiviCRM "files" folder (a.k.a.  `[civicrm.files]`) stores runtime data, such as uploaded images, log files, and
+certain caches.  The folder is created automatically during installation.  However, the default location of this folder
+has evolved.  Deployments which originated on CiviCRM-WordPress circa 4.x should perform a manual update to handle this
+evolution.
+
+!!! note "How has the folder changed?"
+
+    The location of `[civicrm.files]` on WordPress has evolved in the *de facto* typical location:
+
+    | Version | Typical location |
+    | -- | -- |
+    | CiviCRM 4.x | `wp-content/plugins/files/civicrm` |
+    | CiviCRM 5.x | `wp-content/uploads/civicrm` |
+
+    Additionally, there is an evolution in *how* the location is typically calculated:
+
+    | Version | How the location is typically calculated |
+    | -- | -- |
+    | CiviCRM 4.x | Relative to `CIVICRM_TEMPLATE_COMPILEDIR` |
+    | CiviCRM 5.x (before 5.29) | Relative to `CIVICRM_TEMPLATE_COMPILEDIR` |
+    | CiviCRM 5.x (after 5.29) | Relative to `wp_get_upload_dir()` |
+
+!!! note "Why has the location evolved?"
+
+    The original location did not match the WordPress convention for runtime data-storage.  This can create
+    compatibility and installation problems for some hosting environments and configurations that depend on the
+    WordPress conventions.  Using a more standardized location (and more standardized calculation) ultimately
+    simplifies administration and improves compatibility.
+
+!!! note "How do I know what my current location is?"
+
+    There are a few techniques you may use:
+
+    * Look in your web filesystem for the folder (ie `wp-content/plugins/files/civicrm` or `wp-content/uploads/civicrm`).
+      One or the other should exist.
+    * Login to CiviCRM and navigate to `Administer => System Settings => Directories`. Click on the help ("?") icon.
+      Then navigate to `Administer => System Settings => Resource URLs`. Click on the help ("?") icon.
+
+The evolution improves compatibility for new installations, but it poses a challenge for upgrades and maintenance: it
+grows increasingly complex to verify backward-compatibility.  v5.29 may break backward-compatibility for some
+deployments.
+
+There are two ways to prepare for v5.29 and avoid upgrade problems -- set the folder explicitly, or migrate the folder.
+
+!!! tip "Approach 1: Set the folder explicitly"
+
+    By default, CiviCRM calculates the location of `[civicrm.files]` implicitly.  However, if the default calculation
+    is not reliable for your environment, you can override it.  Set the explicit location of `[civicrm.files]` to match
+    your actual, current location:
+
+    1. Determine the local path of the current folder (ex: `/var/www/wp-content/plugins/files/civicrm`)
+    2. Determine the public URL of the current folder (ex: `https://example.com/wp-content/plugins/files/civicrm`)
+    3. Find and edit the file `civicrm.settings.php`. Specify:
+
+       ```php
+       $civicrm_paths['civicrm.files']['path'] = '/var/www/wp-content/plugins/files/civicrm';
+       $civicrm_paths['civicrm.files']['url'] = 'https://example.com/wp-content/plugins/files/civicrm';
+       ```
+
+    The advantage of this approach is that you get full compatibility with little change.
+
+    The disadvantage: if you ever migrate to a different hosting environment (or if you use a staging<=>production
+    process), you will need to update `civicrm.settings.php` to use the new paths and new URLs.
+
+!!! tip "Approach 2: Migrate the folder"
+
+    You may reorganize your files to match the newer defaults. Steps:
+
+    1. Rename the folder `wp-content/plugins/files/civicrm` to `wp-content/uploads/civicrm`.
+    2. In CiviCRM, navigate to `Administer => System Settings => Directories`. If there are any explicit
+       references to the old folder, change them.
+    3. In CiviCRM, navigate to `Administer => System Settings => Resource URLs`. If there are any explicit
+       references to the old folder, change them.
+    4. Find and edit the `civicrm.settings.php`. Change the `CIVICRM_TEMPLATE_COMPILEDIR` to use the new location.
+    5. Modify or redirect any URLs or scripts which reference the older location.
+           * Examples to consider:
+               * Email templates which use images that were previously uploaded
+               * Contact records with photo attachments
+               * External links to assets in downloaded extensions
+               * Backup tools and logging tools which collect information from this folder
+           * Possible techniques:
+               * Directly change the references
+               * Create a symlink between the old/new locations
+               * Configure the HTTP server
+
+    The advantage of this is that your configuration will be more "portable" - e.g. you can more easily migrate
+    data between staging and production systems.
+
+    The disadvantage: finding and correcting old URLs is an open-ended, subjective task. The difficulty of this
+    task depends on both how the system is used (*e.g. Have users uploaded any images?*) and how the system
+    is hosted (*e.g. Does it run on Linux or Windows? Apache or nginx? etc*)
+
+
 ## CiviCRM 5.0
 
 ### Flush CiviCRM cache


### PR DESCRIPTION
Discussion of the impetus for this: https://lab.civicrm.org/dev/wordpress/-/issues/66

Note: The text here refers to changes in 5.29.  The impetus, however, is that the changes were first released in 5.27.  The expectation is that is to revert from 5.27 and then release modified form in 5.29.  However, we should have the docs ready hyperlinking in various comms.