### PR TITLE
add global to code snippet to make it easier to copy and paste

### DIFF
--- a/docs/upgrade/version-specific.md
+++ b/docs/upgrade/version-specific.md
@@ -87,6 +87,7 @@ After determining where the data currently lives, we can suggest a course of act
     3. Find and edit the file `civicrm.settings.php`. Add the correct path and URL:
 
        ```php
+       global $civicrm_paths;
        $civicrm_paths['civicrm.files']['path'] = '/var/www/wp-content/plugins/files/civicrm';
        $civicrm_paths['civicrm.files']['url'] = 'https://example.com/wp-content/plugins/files/civicrm';
        ```


### PR DESCRIPTION
Refrence https://github.com/civicrm/civicrm-core/pull/18068   In testing I left out declaring the global as I copy/pasted from the docs.   Let's add the global in to make it clear that it is needed.