### PR TITLE
Remove JetPack from list - have been using it on multiple sites witho…

### DIFF
--- a/docs/integration/wordpress/incompatibilities.md
+++ b/docs/integration/wordpress/incompatibilities.md
@@ -58,18 +58,6 @@ Because of the huge number and ever-changing nature of community contributed Wor
 * Workaround:  
 * Other comments:  
 
-## JetPack
-
-* Version: all
-* Information last updated on:  
-* Reporter: Workaround - themak
-* Problem: Causes conflict with Backbone JQuery calls
-* Workaround:
-
-    Instead of deactivating Jetpack every time you need to access a profile for a contribution page or edit a date, simply disable the Notifications Module at `http://example.org/wp-admin/admin.php?page=jetpack_modules`
-    
-* Other comments:  
-
 ## "google doc embed plugin"
 
 * Version:  


### PR DESCRIPTION
…ut issue

Remove JetPack from list - have been using it on multiple sites without issue. This is also a very common plugin and if this has issues then there would be lots of recent reports.